### PR TITLE
fix spelling mistakes

### DIFF
--- a/README.org
+++ b/README.org
@@ -69,7 +69,7 @@ This library is my attempt to achieve this vision.
   - Accessing exercise data
   - Book reading progress
   - Messenger stats
-  - Querying Roam Reasearch database
+  - Querying Roam Research database
 - How does it get input data?
 - Q & A
   - Why Python?
@@ -445,7 +445,7 @@ How much do I chat on Facebook Messenger?
 [[https://beepb00p.xyz/messenger_2016_to_2019.png]]
 
 
-** Querying Roam Reasearch database
+** Querying Roam Research database
 I've got some code examples [[https://beepb00p.xyz/myinfra-roam.html#interactive][here]].
 
 * How does it get input data?

--- a/my/core/__main__.py
+++ b/my/core/__main__.py
@@ -15,7 +15,7 @@ import functools
 @functools.lru_cache()
 def mypy_cmd() -> Optional[Sequence[str]]:
     try:
-        # preferrably, use mypy from current python env
+        # preferably, use mypy from current python env
         import mypy
         return ['python3', '-m', 'mypy']
     except ImportError:

--- a/my/core/common.py
+++ b/my/core/common.py
@@ -123,7 +123,7 @@ def _is_compressed(p: Path) -> bool:
     return p.suffix in {'.xz', '.lz4', '.zstd'}
 
 
-# TODO support '' for emtpy path
+# TODO support '' for empty path
 DEFAULT_GLOB = '*'
 def get_files(
         pp: Paths,

--- a/my/github/ghexport.py
+++ b/my/github/ghexport.py
@@ -89,7 +89,7 @@ def stats():
 # TODO hmm. need some sort of abstract syntax for this...
 # TODO split further, title too
 def _get_summary(e) -> Tuple[str, Optional[str], Optional[str]]:
-    # TODO would be nice to give access to raw event withing timeline
+    # TODO would be nice to give access to raw event within timeline
     eid = e['id']
     tp = e['type']
     pl = e['payload']

--- a/my/lastfm/__init__.py
+++ b/my/lastfm/__init__.py
@@ -40,7 +40,7 @@ def inputs() -> Sequence[Path]:
 class Scrobble(NamedTuple):
     raw: Json
 
-    # TODO mm, no timezone? hopefuly it's UTC
+    # TODO mm, no timezone? hopefully it's UTC
     @property
     def dt(self) -> datetime:
         ts = int(self.raw['date'])

--- a/mypy.ini
+++ b/mypy.ini
@@ -7,6 +7,6 @@ show_error_codes   = True
 check_untyped_defs = True
 namespace_packages = True
 
-# it's not controled by me, so for now just ignore..
+# it's not controlled by me, so for now just ignore..
 [mypy-my.config.repos.pdfannots.pdfannots]
 ignore_errors = True

--- a/tests/config.py
+++ b/tests/config.py
@@ -86,7 +86,7 @@ def notes(tmp_path: Path):
 * Weight (org-capture) :weight:
 ** [2020-05-01 Fri 09:00] 62
 ** 63
-    this should be ignored, got no timestmap
+    this should be ignored, got no timestamp
 ** [2020-05-03 Sun 08:00] 61
 ** [2020-05-04 Mon 10:00] 62
     ''')

--- a/tests/demo.py
+++ b/tests/demo.py
@@ -89,7 +89,7 @@ def test_attribute_handling(tmp_path: Path) -> None:
     # mypy doesn't know about it, but the attribute is there
     assert getattr(config, 'irrelevant') == 'hello'
 
-    # check that overriden default attribute is actually getting overridden
+    # check that overridden default attribute is actually getting overridden
     assert config.timezone == nytz
 
 

--- a/tests/takeout.py
+++ b/tests/takeout.py
@@ -23,7 +23,7 @@ def test_location_perf():
 
 
 # in theory should support any HTML takeout file?
-# although IIRC bookmakrs and search-history.html weren't working
+# although IIRC bookmarks and search-history.html weren't working
 import pytest # type: ignore
 @pytest.mark.parametrize(
     'path', [


### PR DESCRIPTION
Couple spelling mistake fixes patched back from my fork. These are all in comments.

Theres another spelling mistake [here](https://github.com/karlicoss/HPI/blob/07dd61ca6ae2b6de20d6954ca1584accede8b762/my/coding/commits.py#L41), (`commited_dt` -> `committed_dt`) but its part of the NamedTuple definition, so I didn't change it; just wanted to let you know incase you wanted to do something about it. (perhaps a `@property` wrapper to maintain backwards compatability? maybe thats pushing it)