### PR TITLE
parse sms messages from xml files

### DIFF
--- a/tests/smscalls.py
+++ b/tests/smscalls.py
@@ -1,6 +1,7 @@
-from my.smscalls import calls
+from my.smscalls import calls, messages
 
 
 # TODO that's a pretty dumb test; perhaps can be generic..
 def test():
     assert len(list(calls())) > 10
+    assert len(list(messages())) > 10


### PR DESCRIPTION
pretty isolated change and already present here, so relatively easy to PR this.

not sure about the `datetime`s, have been thinking about that in general.

I have a [helper function](https://github.com/seanbreckenridge/HPI/blob/3d95c787153ce0d3b9e63f399f4293401fbb7439/my/core/time.py#L21-L26) to parse epoch times like this, but not sure if I should instead be putting it in local timezone/leaving it in UTC. UTC seems safe for now.