### PR TITLE
initial timezone provider (location based + fallbacks)

### DIFF
--- a/doc/example_config/my/config/__init__.py
+++ b/doc/example_config/my/config/__init__.py
@@ -32,3 +32,7 @@ class bluemaestro:
 
 class google:
     takeout_path: Paths = ''
+
+class location:
+    class home:
+        current = (1.0, -1.0)

--- a/my/google/takeout/paths.py
+++ b/my/google/takeout/paths.py
@@ -7,6 +7,9 @@ from ...core.common import Paths, get_files
 from ...core.util import __NOT_HPI_MODULE__
 
 from my.config import google as user_config
+
+from more_itertools import last
+
 @dataclass
 class google(user_config):
     takeout_path: Paths # path/paths/glob for the takeout zips
@@ -35,9 +38,7 @@ def get_takeouts(*, path: Optional[str]=None) -> Iterable[Path]:
 
 
 def get_last_takeout(*, path: Optional[str]=None) -> Path:
-    # TODO more_itertools?
-    matching = list(get_takeouts(path=path))
-    return matching[-1]
+    return last(get_takeouts(path=path))
 
 
 # TODO might be a good idea to merge across multiple takeouts...

--- a/my/kython/kompress.py
+++ b/my/kython/kompress.py
@@ -28,7 +28,11 @@ def kopen(path: PathIsh, *args, mode: str='rt', **kwargs) -> IO[str]:
     suf = pp.suffix
     if suf in {'.xz'}:
         import lzma
-        return lzma.open(pp, mode, *args, **kwargs)
+        r = lzma.open(pp, mode, *args, **kwargs)
+        # should only happen for binary mode?
+        # file:///usr/share/doc/python3/html/library/lzma.html?highlight=lzma#lzma.open
+        assert not isinstance(r, lzma.LZMAFile), r
+        return r
     elif suf in {'.zip'}:
         # eh. this behaviour is a bit dodgy...
         from zipfile import ZipFile

--- a/my/location/google.py
+++ b/my/location/google.py
@@ -18,7 +18,6 @@ import geopy # type: ignore
 
 from ..core.common import LazyLogger, mcachew
 from ..core.cachew import cache_dir
-from ..google.takeout.paths import get_last_takeout
 from ..kython import kompress
 
 
@@ -148,7 +147,9 @@ def _iter_locations(path: Path, start=0, stop=None) -> Iterator[Location]:
 
 
 def locations(**kwargs) -> Iterator[Location]:
-    # TODO need to include older data
+    # NOTE: if this import isn't lazy, tests/tz.py breaks because it can't override config
+    # very weird, as if this function captures the values of globals somehow?? investigate later.
+    from ..google.takeout.paths import get_last_takeout
     last_takeout = get_last_takeout(path=_LOCATION_JSON)
 
     return _iter_locations(path=last_takeout, **kwargs)

--- a/my/location/home.py
+++ b/my/location/home.py
@@ -1,0 +1,61 @@
+'''
+Simple location provider, serving as a fallback when more detailed data isn't available
+'''
+from dataclasses import dataclass
+from datetime import datetime, date
+from functools import lru_cache
+from typing import Optional, Sequence, Tuple, Union
+
+from ..core.common import fromisoformat
+
+from my.config import location as L
+user_config = L.home
+
+
+DateIsh = Union[datetime, str]
+
+# todo hopefully reasonable? might be nice to add name or something too
+LatLon = Tuple[float, float]
+
+@dataclass
+class home(user_config):
+    # TODO could make current Optional and somehow determine from system settings?
+    # todo possibly also could be core config.. but not sure
+    current: LatLon
+
+    '''
+    First element is location, the second is the date when you left it (datetime/ISO string)
+    '''
+    past: Sequence[Tuple[LatLon, DateIsh]] = ()
+    # todo test for proper localized/not localized handling as well
+    # todo make sure they are increasing
+
+
+    @property
+    def _past(self) -> Sequence[Tuple[LatLon, datetime]]:
+        # todo cache?
+        res = []
+        for loc, x in self.past:
+            dt: datetime
+            if isinstance(x, str):
+                dt = fromisoformat(x)
+            else:
+                dt = x
+            res.append((loc, dt))
+        return res
+
+        
+
+from ..core.cfg import make_config
+config = make_config(home)
+
+
+@lru_cache(maxsize=None)
+def get_location(dt: datetime) -> LatLon:
+    '''
+    Interpolates the location at dt
+    '''
+    for loc, pdt in config._past:
+        if dt <= pdt:
+            return loc
+    return config.current

--- a/my/time/tz/main.py
+++ b/my/time/tz/main.py
@@ -1,0 +1,9 @@
+'''
+Timezone data provider
+'''
+from datetime import datetime
+
+def localize(dt: datetime) -> datetime:
+    # For now, it's user's reponsibility to check that it actually managed to localize
+    from . import via_location as L
+    return L.localize(dt)

--- a/tests/tz.py
+++ b/tests/tz.py
@@ -13,6 +13,15 @@ def test_iter_tzs() -> None:
     assert len(ll) > 3
 
 
+def test_past() -> None:
+    # should fallback to the home location provider
+    dt = D('20000101 12:34:45')
+    dt = TZ.localize(dt)
+    tz = dt.tzinfo
+    assert tz is not None
+    assert getattr(tz, 'zone') == 'America/New_York'
+
+
 def test_future() -> None:
     fut = datetime.now() + timedelta(days=100)
     # shouldn't crash at least
@@ -55,8 +64,16 @@ def prepare(tmp_path: Path):
 
     # FIXME ugh. early import/inheritance of user_confg in my.google.takeout.paths messes things up..
     from my.cfg import config
-    class user_config:
+    class google:
         takeout_path = tmp_path
-    config.google = user_config # type: ignore
+    config.google = google # type: ignore
+
+    class location:
+        class home:
+            current = (1.0, 1.0)
+            past = [
+                ((40.7128, -74.0060), '2005-12-04'), # NY
+            ]
+    config.location = location # type: ignore
 
     yield

--- a/tests/tz.py
+++ b/tests/tz.py
@@ -1,0 +1,62 @@
+from datetime import datetime, timedelta
+from pathlib import Path
+import sys
+
+import pytest # type: ignore
+
+import my.time.tz.main as TZ
+import my.time.tz.via_location as LTZ
+
+
+def test_iter_tzs() -> None:
+    ll = list(LTZ._iter_tzs())
+    assert len(ll) > 3
+
+
+def test_future() -> None:
+    fut = datetime.now() + timedelta(days=100)
+    # shouldn't crash at least
+    assert TZ.localize(fut) is not None
+
+
+def test_tz() -> None:
+    # not present in the test data
+    tz = LTZ._get_tz(D('20200101 10:00:00'))
+    assert tz is None
+
+    tz = LTZ._get_tz(D('20170801 11:00:00'))
+    assert tz is not None
+    assert tz.zone == 'Europe/Vienna'
+
+    tz = LTZ._get_tz(D('20170730 10:00:00'))
+    assert tz is not None
+    assert tz.zone == 'Europe/Rome'
+
+
+def D(dstr: str) -> datetime:
+    return datetime.strptime(dstr, '%Y%m%d %H:%M:%S')
+
+
+# TODO copy pasted from location.py, need to extract some common provider
+@pytest.fixture(autouse=True)
+def prepare(tmp_path: Path):
+    LTZ._FASTER = True
+
+    from more_itertools import one
+    testdata = Path(__file__).absolute().parent.parent / 'testdata'
+    assert testdata.exists(), testdata
+
+    track = one(testdata.rglob('italy-slovenia-2017-07-29.json'))
+
+    # todo ugh. unnecessary zipping, but at the moment takeout provider doesn't support plain dirs
+    import zipfile
+    with zipfile.ZipFile(tmp_path / 'takeout.zip', 'w') as zf:
+        zf.writestr('Takeout/Location History/Location History.json', track.read_bytes())
+
+    # FIXME ugh. early import/inheritance of user_confg in my.google.takeout.paths messes things up..
+    from my.cfg import config
+    class user_config:
+        takeout_path = tmp_path
+    config.google = user_config # type: ignore
+
+    yield

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,9 @@ commands =
     # my.location.google deps
     pip install geopy ijson
 
+    # my.time.tz.via_location dep
+    pip install timezonefinder
+
     python3 -m pytest                              \
         tests/core.py                              \
         tests/misc.py                              \
@@ -25,7 +28,8 @@ commands =
         tests/config.py::test_environment_variable \
         tests/demo.py                              \
         tests/bluemaestro.py                       \
-        tests/location.py
+        tests/location.py                          \
+        tests/tz.py
     # TODO add; once I figure out porg depdencency?? tests/config.py
     # TODO run demo.py? just make sure with_my is a bit cleverer?
     # TODO e.g. under CI, rely on installing
@@ -63,6 +67,7 @@ commands =
                     -p my.body.exercise.cross_trainer \
                     -p my.bluemaestro                 \
                     -p my.location.google             \
+                    -p my.time.tz.via_location        \
                     --txt-report  .mypy-coverage      \
                     --html-report .mypy-coverage      \
                     {posargs}


### PR DESCRIPTION
@seanbreckenridge this is what I've mentioned in https://github.com/karlicoss/HPI/pull/90#issuecomment-702433027 

The idea is that you can use `localize` method against a timezone-unaware date, and it will determine it from google location (later can think of using other location provider too, I've got some gpslogger stuff). If it can't do it based on the precise location data, it determines based on `my.location.home`.

For now the resolution is day-based, but I'll experiment a bit more and later will implement it to be more precise.

So far, I've only been using it on caller sites, whereas would be kind of cool to do it from within HPI itself (e.g. with sms provider, we already know it's UTC so no point in forcing the user to figure that out). But I feel like it would be good to experiment a bit more first to make sure. Also would need to make it a bit more defensive, so if the user doesn't have location data, it's not crashing everything.

