### PR TITLE
add similar projects to README

### DIFF
--- a/README.org
+++ b/README.org
@@ -689,6 +689,8 @@ Similar projects:
 - [[https://github.com/bcongdon/bolero][bcongdon/bolero]]: exposes your personal data as a REST API
 - [[https://en.wikipedia.org/wiki/Solid_(web_decentralization_project)#Design][Solid project]]: personal data pod, which websites pull data from
 - [[https://remotestorage.io][remoteStorage]]: open protocol for apps to write data to your own storage
+- [[https://perkeep.org]][Perkeep]: a tool with [[https://perkeep.org/doc/principles]][principles] and esp. [[https://perkeep.org/doc/uses]][use cases] for self-sovereign storage of personal data
+- [[https://www.openhumans.org]][Open Humans]: a community and infrastructure to analyse and share personal data
 
 Other links:
 


### PR DESCRIPTION
In preparation of an attempt to regain autonomy of my very own personal data, I have been researching into the field in the past years and consider these two additions important enough to propose them here.

- Perkeep, formerly known as Camlistore, is a content-addressable storage for personal data that has been around for long and also seeks a wider adoption base. People interested in the HPI might also find a very useful infrastructure in that.
- Open Humans is an online community from dedicated researchers that aim at easing the process of obtaining and analysing certain available personal data sets. Their infrastructure includes surveys as well as interactive notebooks with secure access to a personal data store and API integrations for receiving archives from third party services.