### PR TITLE
fix mypy errors

### DIFF
--- a/my/arbtt.py
+++ b/my/arbtt.py
@@ -90,7 +90,7 @@ def entries() -> Iterable[Entry]:
 
 def fill_influxdb() -> None:
     from .core.influxdb import magic_fill
-    from .core.types import Freezer
+    from .core.freezer import Freezer
     freezer = Freezer(Entry)
     fit = (freezer.freeze(e) for e in entries())
     # TODO crap, influxdb doesn't like None https://github.com/influxdata/influxdb/issues/7722

--- a/my/core/freezer.py
+++ b/my/core/freezer.py
@@ -2,7 +2,7 @@ from .common import assert_subpackage; assert_subpackage(__name__)
 
 import dataclasses as dcl
 import inspect
-from typing import TypeVar, Type
+from typing import TypeVar, Type, Any
 
 D = TypeVar('D')
 
@@ -40,23 +40,27 @@ class Freezer(Generic[D]):
 
 ### tests
 
+
+# this needs to be defined here to prevent a mypy bug
+# see https://github.com/python/mypy/issues/7281
+@dcl.dataclass
+class _A:
+    x: Any
+
+    # TODO what about error handling?
+    @property
+    def typed(self) -> int:
+        return self.x['an_int']
+
+    @property
+    def untyped(self):
+        return self.x['an_any']
+
+
 def test_freezer() -> None:
-    from typing import Any
-    @dcl.dataclass
-    class A:
-        x: Any
 
-        # TODO what about error handling?
-        @property
-        def typed(self) -> int:
-            return self.x['an_int']
-
-        @property
-        def untyped(self):
-            return self.x['an_any']
-
-    val = A(x=dict(an_int=123, an_any=[1, 2, 3]))
-    af = Freezer(A)
+    val = _A(x=dict(an_int=123, an_any=[1, 2, 3]))
+    af = Freezer(_A)
     fval = af.freeze(val)
 
     fd = vars(fval)

--- a/my/core/serialize.py
+++ b/my/core/serialize.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Any, Optional, Callable
+from typing import Any, Optional, Callable, NamedTuple
 from functools import lru_cache
 
 from .common import is_namedtuple
@@ -137,17 +137,18 @@ def test_serialize_fallback() -> None:
 
 
 
+# this needs to be defined here to prevent a mypy bug
+# see https://github.com/python/mypy/issues/7281
+class _A(NamedTuple):
+    x: int
+    y: float
+
+
 def test_nt_serialize() -> None:
     import json as jsn  # dont cause possible conflicts with module code
     import orjson  # import to make sure this is installed
 
-    from typing import NamedTuple
-
-    class A(NamedTuple):
-        x: int
-        y: float
-
-    res: str = dumps(A(x=1, y=2.0))
+    res: str = dumps(_A(x=1, y=2.0))
     assert res == '{"x":1,"y":2.0}'
 
     # test orjson option kwarg

--- a/tests/core.py
+++ b/tests/core.py
@@ -16,6 +16,6 @@ from my.core.core_config    import *
 from my.core.error          import *
 from my.core.util           import *
 from my.core.discovery_pure import *
-from my.core.types          import *
+from my.core.freezer        import *
 from my.core.stats          import *
 from my.core.serialize      import test_serialize_fallback


### PR DESCRIPTION
this fixes two distinct mypy errors

one where NamedTuple/dataclassees can't be
defined locally
https://github.com/python/mypy/issues/7281

which happens when you run mypy like
mypy -p my.core on warm cache

the second error is the core/types.py file shadowing the
stdlib types module

![image](https://user-images.githubusercontent.com/7804791/111918367-0453af80-8a42-11eb-8cb8-03b9ddeac1d4.png)