### PR TITLE
my.core.serialize: support serializing Paths

### DIFF
--- a/my/core/serialize.py
+++ b/my/core/serialize.py
@@ -1,4 +1,5 @@
 import datetime
+from pathlib import Path
 from typing import Any, Optional, Callable, NamedTuple
 from functools import lru_cache
 
@@ -25,6 +26,9 @@ def _default_encode(obj: Any) -> Any:
         return obj._asdict()
     if isinstance(obj, datetime.timedelta):
         return obj.total_seconds()
+    # convert paths to their string representation
+    if isinstance(obj, Path):
+        return str(obj)
     if isinstance(obj, Exception):
         return error_to_json(obj)
     # note: _serialize would only be called for items which aren't already


### PR DESCRIPTION
Thought this might be useful as lots of functionality in HPI uses Paths

This also is helpful for [`HPI_API`](https://github.com/seanbreckenridge/HPI_API) as some of the input functions there use Paths, so that info would then be accessible


```python
In [1]: from my.reddit import inputs

In [2]: inps = list(inputs())

In [3]: inps
Out[3]:
[PosixPath('/home/sean/data/rexport/20200930T214405Z.json'),
 PosixPath('/home/sean/data/rexport/20201229T214451Z.json'),
 PosixPath('/home/sean/data/rexport/20210322T104557Z.json')]

In [4]: from my.core.serialize import dumps

In [5]: dumps(inps)
Out[5]: '["/home/sean/data/rexport/20200930T214405Z.json","/home/sean/data/rexport/20201229T214451Z.json","/home/sean/data/rexport/20210322T104557Z.json"]'

```

```
curl 'http://localhost:5050/my/reddit/inputs'
{"page":1,"limit":50,"items":["/home/sean/data/rexport/20200930T214405Z.json","/home/sean/data/rexport/20201229T214451Z.json","/home/sean/data/rexport/20210322T104557Z.json"]}
```