### PR TITLE
switch CLI to using click, handles printing colors

### DIFF
--- a/my/core/__main__.py
+++ b/my/core/__main__.py
@@ -437,11 +437,10 @@ def module_install_cmd(user: bool, module: str) -> None:
 
 
 def test_doctor_single():
-    # cli test
     from click.testing import CliRunner
-    result = CliRunner().invoke(main, ['doctor', '--skip-config-check', 'my.core'])
+    result = CliRunner().invoke(main, ['module', 'requires', 'my.github.ghexport'])
     assert result.exit_code == 0
-    assert "no 'stats' function" in result.output
+    assert "github.com/karlicoss/ghexport" in result.output
 
 
 if __name__ == '__main__':

--- a/my/core/__main__.py
+++ b/my/core/__main__.py
@@ -436,7 +436,7 @@ def module_install_cmd(user: bool, module: str) -> None:
 # other python code
 
 
-def test_doctor_single():
+def test_requires() -> None:
     from click.testing import CliRunner
     result = CliRunner().invoke(main, ['module', 'requires', 'my.github.ghexport'])
     assert result.exit_code == 0

--- a/my/core/__main__.py
+++ b/my/core/__main__.py
@@ -207,7 +207,7 @@ def _modules(*, all: bool=False) -> Iterable[HPIModule]:
         warning(f'Skipped {len(skipped)} modules: {skipped}. Pass --all if you want to see them.')
 
 
-def modules_check(verbose: bool, list_all: bool, quick: bool, for_modules: Sequence[str]) -> None:
+def modules_check(verbose: bool, list_all: bool, quick: bool, for_modules: List[str]) -> None:
     if len(for_modules) > 0:
         # if you're checking specific modules, show errors
         # hopefully makes sense?
@@ -223,7 +223,7 @@ def modules_check(verbose: bool, list_all: bool, quick: bool, for_modules: Seque
     from .stats import guess_stats
 
     mods: Iterable[HPIModule]
-    if for_modules == []:
+    if len(for_modules) == 0:
         mods = _modules(all=list_all)
     else:
         mods = [HPIModule(name=m, skip_reason=None) for m in for_modules]
@@ -370,7 +370,7 @@ def doctor_cmd(verbose: bool, list_all: bool, quick: bool, skip_conf: bool, modu
     if not skip_conf:
         config_ok()
     # TODO check that it finds private modules too?
-    modules_check(verbose, list_all, quick, module)
+    modules_check(verbose, list_all, quick, list(module))
 
 
 @main.group(name='config', short_help='work with configuration')

--- a/my/core/warnings.py
+++ b/my/core/warnings.py
@@ -9,6 +9,9 @@ import sys
 from typing import Optional
 import warnings
 
+import click
+
+
 # just bring in the scope of this module for convenience
 from warnings import warn
 
@@ -18,16 +21,11 @@ def _colorize(x: str, color: Optional[str]=None) -> str:
 
     if not sys.stdout.isatty():
         return x
+    # click handles importing/initializing colorama if necessary
+    # on windows it installs it if necessary
+    # on linux/mac, it manually handles ANSI without needing termcolor
+    return click.style(x, fg=color)
 
-    # I'm not sure about this approach yet, so don't want to introduce a hard dependency yet
-    try:
-        import termcolor # type: ignore[import]
-        import colorama # type: ignore[import]
-        colorama.init()
-        return termcolor.colored(x, color)
-    except:
-        # todo log something?
-        return x
 
 def _warn(message: str, *args, color: Optional[str]=None, **kwargs) -> None:
     stacklevel = kwargs.get('stacklevel', 1)

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ INSTALL_REQUIRES = [
     'appdirs',        # very common, and makes it portable
     'more-itertools', # it's just too useful and very common anyway
     'decorator'     , # less pain in writing correct decorators. very mature and stable, so worth keeping in core
+    'click'         , # for the CLI, printing colors, decorator-based - may allow extensions to CLI
 ]
 
 

--- a/tests/core.py
+++ b/tests/core.py
@@ -20,3 +20,4 @@ from my.core.freezer        import *
 from my.core.stats          import *
 from my.core.query          import *
 from my.core.serialize      import test_serialize_fallback
+from my.core.__main__       import *


### PR DESCRIPTION
docs for click are good, would recommend skimming over them
https://click.palletsprojects.com/en/7.x/#documentation

everything is backwards-compatible with the previous interface, the only minor changes were to the `doctor` cmd which can now accept more than one item to run, and the `--skip-config-check` to skip the `config_ok` check if the user specifies to

Couldn't find anywhere in the `doc/` folder where I had to change, let me know if I missed something

added a test using `click.testing.CliRunner` (tests the CLI in an isolated environment), though additional tests which aren't testing the CLI itself (parsing arguments or decorator behaviour) can just call the functions themselves, as they no longer accept a argparser.Namespace and instead accept the direct arguments

I also replaced the `colorama.init` call in core.warnings, as click will make sure colorama is installed on windows if it needs it, and handles initializing it if needed, else it does typical ANSI-styled colors with [`click.style`](https://click.palletsprojects.com/en/7.x/api/#click.style). This **doesnt** use termcolor under the hood, it just does it manually (other than colorama on windows, click has no dependencies)

I know previously said that would PR this after writing the query interface, but didn't want to have to worry about making it compatible with argparse and click (and also, didn't feel like writing something in argparse, knowing I would re-write it almost immediately)

Does change the formatting for the CLI a bit (doesnt use epilog, uses the docstrings as descriptions), but the decorators and nesting is pretty readable. Any `click.group()` functions can then be used as a decorator themslelves, allowing you to nest like:

```python
@click.group():
def main():
	pass
	
@main.group()
def subgroup():
	pass

# options with '/' are interpreted as on/off flags
@subgroup.command()
@click.option("--verbose/--quiet", default=False, help="increase verbosity...")
def cmd(verbose: bool) -> None:
	"""docs for cmd go here"""
	click.echo("Hi!")
```

That would create an interface like `main.py subgroup cmd`, allowing you to add `click.options()` or `click.arguments()` along the way. Click supports lots of ways to deal with the complexities of parsing/sharing context between the groups and options, either adding callbacks, invoking one command from another, or adding a shared context between commands. [Advanced docs](https://click.palletsprojects.com/en/7.x/advanced/#invoking-other-commands)

Also, switched from using `print` to `click.echo` since it handles handles possible UnicodeErrors if the terminal is heavily misconfigured, strips ANSI colors if the output is a file. Overhead is tiny so I tend to use it by default so I don't have to worry about those problems in the future

the only major thing I think isn't immediately obvious is in click:

> Arguments work similarly to options but are positional. They also only support a subset of the features of options due to their syntactical nature. Click will also not attempt to document arguments for you and wants you to document them manually in order to avoid ugly help pages

So any documentation for arguments is done manually in the docstring

here are some examples of using the interface:

```
[ ~/Repos/HPI-to-master | click ] $ hpi module requires my.reddit
dependencies of my.reddit
'git+https://github.com/karlicoss/rexport'
'git+https://github.com/seanbreckenridge/pushshift_comment_export'
[ ~/Repos/HPI-to-master | click ] $ hpi module install --help
Usage: hpi module install [OPTIONS] MODULE

  Install dependencies for a module using pip

  MODULE is a specific module name (e.g. my.reddit)

Options:
  --user  same as pip --user
  --help  Show this message and exit.
```

```
[ ~/Repos/HPI-to-master | click ] $ hpi doctor --skip-config-check my.reddit my.github.all
✅ OK  : my.reddit
✅     - stats: {'saved': {'count': 51, 'last': datetime.datetime(2016, 9, 26, 0, 13, 19, tzinfo=<UTC>)}, 'comments': {'count': 4914}, 'submissions': {'count': 39}, 'upvoted': {'count': 923}}
✅ OK  : my.github.all
✅     - stats: {'events': {'events': {'count': 5697, 'last': datetime.datetime(2021, 4, 3, 7, 24, 37, tzinfo=<UTC>)}}, 'get_events': {'get_events': {'count': 5697, 'last': datetime.datetime(2021, 4, 3, 7, 24, 37, tzinfo=<UTC>)}}}
```

Only other thing I was worried about is adding a core dependency without a check?

If someone else is using this as an editable package and `git pulls` periodically to update this, and they didn't happen to have `click` installed (low chance given its popularity, but still), the `import click` would just fail

perhaps I should add something like?

```python
try:
	import click
except ModuleNotFoundError:
	print("this requires click for the user interface now.. run : python3 -m pip install --user click")
	sys.exit(1)
```