### PR TITLE
my.coding.commits: fix misspelling/add warning

### DIFF
--- a/my/coding/commits.py
+++ b/my/coding/commits.py
@@ -56,7 +56,7 @@ def by_me(c: git.objects.commit.Commit) -> bool:
 
 @dataclass
 class Commit:
-    commited_dt: datetime
+    committed_dt: datetime
     authored_dt: datetime
     message: str
     repo: str # TODO put canonical name here straightaway??
@@ -66,7 +66,13 @@ class Commit:
 
     @property
     def dt(self) -> datetime:
-        return self.commited_dt
+        return self.committed_dt
+
+    # for backwards compatibility, was misspelled previously
+    @property
+    def commited_dt(self) -> datetime:
+        high("DEPRECATED! Please replace 'commited_dt' with 'committed_dt' (two 't's instead of one)")
+        return self.committed_dt
 
 
 # TODO not sure, maybe a better idea to move it to timeline?
@@ -101,7 +107,7 @@ def _repo_commits_aux(gr: git.Repo, rev: str, emitted: Set[str]) -> Iterator[Com
         repo = str(_git_root(gr.git_dir))
 
         yield Commit(
-            commited_dt=fix_datetime(c.committed_datetime),
+            committed_dt=fix_datetime(c.committed_datetime),
             authored_dt=fix_datetime(c.authored_datetime),
             message=c.message.strip(),
             repo=repo,


### PR DESCRIPTION
should fix https://github.com/karlicoss/HPI/issues/147, unless you wanted to vendorize/add something like [tantale/deprecated](https://github.com/tantale/deprecated)

personally think sending the warnings manually is fine