### PR TITLE
query interactive fallback, improve guess_stats

### DIFF
--- a/my/core/query.py
+++ b/my/core/query.py
@@ -56,7 +56,7 @@ def locate_function(module_name: str, function_name: str) -> Callable[[], Iterab
                 return func
     except Exception as e:
         raise QueryException(str(e))
-    raise QueryException(f"Could not find function {function_name} in {module_name}")
+    raise QueryException(f"Could not find function '{function_name}' in '{module_name}'")
 
 
 def locate_qualified_function(qualified_name: str) -> Callable[[], Iterable[ET]]:

--- a/my/core/stats.py
+++ b/my/core/stats.py
@@ -6,7 +6,7 @@ import importlib
 import inspect
 import sys
 import typing
-from typing import Optional, Callable, Any, List, Iterator
+from typing import Optional, Callable, Any, Iterator
 
 from .common import StatsFun, Stats, stat
 
@@ -85,7 +85,7 @@ def sig_required_params(sig: inspect.Signature) -> Iterator[inspect.Parameter]:
             yield param
 
 
-def test_sig_required_args() -> None:
+def test_sig_required_params() -> None:
 
     def x() -> int:
         return 5

--- a/my/core/stats.py
+++ b/my/core/stats.py
@@ -37,7 +37,7 @@ def is_data_provider(fun: Any) -> bool:
     # todo. uh.. very similar to what cachew is trying to do?
     try:
         sig = inspect.signature(fun)
-    except ValueError:  # not a function?
+    except (ValueError, TypeError):  # not a function?
         return False
 
     # has at least one argument without default values
@@ -56,6 +56,7 @@ def test_is_data_provider() -> None:
     idp = is_data_provider
     assert not idp(None)
     assert not idp(int)
+    assert not idp("x")
 
     def no_return_type():
         return [1, 2 ,3]

--- a/my/core/stats.py
+++ b/my/core/stats.py
@@ -45,7 +45,7 @@ def is_data_provider(fun: Any) -> bool:
         return False
 
     # probably a helper function?
-    if fun.__name__.startswith("_"):
+    if hasattr(fun, '__name__') and fun.__name__.startswith('_'):
         return False
 
     return_type = sig.return_annotation

--- a/my/core/stats.py
+++ b/my/core/stats.py
@@ -6,7 +6,7 @@ import importlib
 import inspect
 import sys
 import typing
-from typing import Optional
+from typing import Optional, Callable, Any, List, Iterator
 
 from .common import StatsFun, Stats, stat
 
@@ -24,14 +24,18 @@ def guess_stats(module_name: str) -> Optional[StatsFun]:
     return auto_stats
 
 
-def is_data_provider(fun) -> bool:
+def is_data_provider(fun: Any) -> bool:
     """
     1. returns iterable or something like that
     2. takes no arguments? (otherwise not callable by stats anyway?)
+    3. doesn't start with an underscore (those are probably helper functions?)
     """
     # todo maybe for 2 allow default arguments? not sure
     # one example which could benefit is my.pdfs
     if fun is None:
+        return False
+    # probably a helper function?
+    if fun.__name__.startswith("_"):
         return False
     # todo. uh.. very similar to what cachew is trying to do?
     try:
@@ -39,8 +43,10 @@ def is_data_provider(fun) -> bool:
     except ValueError:  # not a function?
         return False
 
-    if len(sig.parameters) > 0:
+    # has at least one argument without default values
+    if len(list(sig_required_params(sig))) > 0:
         return False
+
     return_type = sig.return_annotation
     return type_is_iterable(return_type)
 
@@ -64,6 +70,35 @@ def test_is_data_provider() -> None:
     def has_return_type() -> typing.Sequence[str]:
         return ['a', 'b', 'c']
     assert idp(has_return_type)
+
+    def _helper_func() -> Iterator[Any]:
+        yield 5
+    assert not idp(_helper_func)
+
+
+# return any parameters the user is required to provide - those which don't have default values
+def sig_required_params(sig: inspect.Signature) -> Iterator[inspect.Parameter]:
+    for param in sig.parameters.values():
+        if param.default == inspect.Parameter.empty:
+            yield param
+
+
+def test_sig_required_args() -> None:
+
+    def x() -> int:
+        return 5
+    assert len(list(sig_required_params(inspect.signature(x)))) == 0
+
+    def y(arg: int) -> int:
+        return arg
+    assert len(list(sig_required_params(inspect.signature(y)))) == 1
+
+    # from stats perspective, this should be treated as a data provider as well
+    # could be that the default value to the data provider is the 'default'
+    # path to use for inputs/a function to provide input data
+    def z(arg: int = 5) -> int:
+        return arg
+    assert len(list(sig_required_params(inspect.signature(z)))) == 0
 
 
 def type_is_iterable(type_spec) -> bool:

--- a/my/core/stats.py
+++ b/my/core/stats.py
@@ -34,9 +34,6 @@ def is_data_provider(fun: Any) -> bool:
     # one example which could benefit is my.pdfs
     if fun is None:
         return False
-    # probably a helper function?
-    if fun.__name__.startswith("_"):
-        return False
     # todo. uh.. very similar to what cachew is trying to do?
     try:
         sig = inspect.signature(fun)
@@ -45,6 +42,10 @@ def is_data_provider(fun: Any) -> bool:
 
     # has at least one argument without default values
     if len(list(sig_required_params(sig))) > 0:
+        return False
+
+    # probably a helper function?
+    if fun.__name__.startswith("_"):
         return False
 
     return_type = sig.return_annotation


### PR DESCRIPTION
changes to guess_stats:

  ignore items that start with underscores -- probably helpers
  inspect the signature parameters to check which items dont have default values

changes to `hpi query`:

Added an interactive fallback to the query interface, where if you specify something like:
`my.reddit` instead of `my.reddit.comments`, it uses `is_data_provider` to try
and find possible functions to call. Looks like:

```
$ hpi query my.reddit -o repl
Which function should be used from 'my.reddit'?

        1. comment_inputs
        2. comments
        3. inputs
        4. pushshift_comments
        5. saved
        6. submissions
        7. upvoted

(Note: if you dont select something in the allowed range)
f not in ['1', '2', '3', '4', '5', '6', '7']
Selected 'inputs'

Interact with the results by using the res variable

Python 3.9.3 (default, Apr  8 2021, 23:35:02)
Type 'copyright', 'credits' or 'license' for more information
IPython 7.22.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: res
Out[1]:
[PosixPath('/home/sean/data/rexport/20200930T214405Z.json'),
 PosixPath('/home/sean/data/rexport/20201229T214451Z.json'),
 PosixPath('/home/sean/data/rexport/20210322T104557Z.json')]
```

Previous behaviour still works, can provide a fully qualified path:

```
hpi query my.reddit.inputs
["/home/sean/data/rexport/20200930T214405Z.json","/home/sean/data/rexport/20201229T214451Z.json","/home/sean/data/rexport/20210322T104557Z.json"]
```

