### PR TITLE
cli/query: bugfix where datetime was ignored

### DIFF
--- a/my/core/__main__.py
+++ b/my/core/__main__.py
@@ -672,7 +672,7 @@ def query_cmd(
     chosen_order_type: Optional[Type]
     if order_type == "datetime":
         chosen_order_type = datetime
-    if order_type == "date":
+    elif order_type == "date":
         chosen_order_type = date
     elif order_type == "int":
         chosen_order_type = int


### PR DESCRIPTION
missed an elif by mistake, realized
this was an issue when I tried
the example in the --help text
and it failed
