### PR TITLE
cli/query: bugfix, convert output to list

### DIFF
--- a/my/core/__main__.py
+++ b/my/core/__main__.py
@@ -460,8 +460,9 @@ def query_hpi_functions(
     elif output == 'pprint':
         from pprint import pprint
 
-        pprint(res)
+        pprint(list(res))
     else:
+        res = list(res)
         # output == 'repl'
         eprint(f"\nInteract with the results by using the {click.style('res', fg='green')} variable\n")
         try:

--- a/my/core/__main__.py
+++ b/my/core/__main__.py
@@ -462,7 +462,7 @@ def query_hpi_functions(
 
         pprint(list(res))
     else:
-        res = list(res)
+        res = list(res)  # type: ignore[assignment]
         # output == 'repl'
         eprint(f"\nInteract with the results by using the {click.style('res', fg='green')} variable\n")
         try:


### PR DESCRIPTION
my mistake, I only really use the json
output option so forgot to test these

since I never converted `res` to a list
so it could be consumed either way by the
JSON option, pprint and repl have
to convert it to a list below
