### PR TITLE
smscalls: allow multiple backup dirs

### DIFF
--- a/my/config.py
+++ b/my/config.py
@@ -24,6 +24,9 @@ class hypothesis:
 class instapaper:
     export_path: Paths = ''
 
+class smscalls:
+    export_path: Paths = ''
+
 class pocket:
     export_path: Paths = ''
 

--- a/my/smscalls.py
+++ b/my/smscalls.py
@@ -5,13 +5,13 @@ Exported using https://play.google.com/store/apps/details?id=com.riteshsahu.SMSB
 
 REQUIRES = ['lxml']
 
-from .core import PathIsh, dataclass
+from .core import Paths, dataclass
 from my.config import smscalls as user_config
 
 @dataclass
 class smscalls(user_config):
-    # directory that SMSBackupRestore syncs XML files to
-    export_path: PathIsh
+    # path[s] that SMSBackupRestore syncs XML files to
+    export_path: Paths
 
 from .core.cfg import make_config
 config = make_config(smscalls)

--- a/tox.ini
+++ b/tox.ini
@@ -85,6 +85,7 @@ commands =
     hpi module install my.coding.commits
     hpi module install my.goodreads
     hpi module install my.pdfs
+    hpi module install my.smscalls
 
     # todo fuck. -p my.github isn't checking the subpackages?? wtf...
     # guess it wants .pyi file??
@@ -94,6 +95,7 @@ commands =
                     -p my.hypothesis                  \
                     -p my.instapaper                  \
                     -p my.pocket                      \
+                    -p my.smscalls                    \
                     -p my.reddit                      \
                     -p my.stackexchange.stexport      \
                     -p my.pinboard                    \


### PR DESCRIPTION
ran into an issue recently configuring smsbackuprestore, couldn't supply multiple directories since its typed as `PathIsh` instead of `Paths` -- this change is backwards compatible, so I don't think it should be an issue

so my config now looks like:

```python
class smscalls:
    export_path: Paths = ("~/data/SMSBackups", "~/data/phone/SMSBackups")
```

Works fine this way as well:

```python
In [1]: from my.core import get_files

In [2]: from my.config import smscalls

In [3]: smscalls.export_path
Out[3]:
(PosixPath('/home/sean/data/SMSBackups'),
 PosixPath('/home/sean/data/phone/SMSBackups'))

In [4]: get_files(smscalls.export_path, glob='calls-*.xml')
Out[4]:
(PosixPath('/home/sean/data/SMSBackups/calls-20210509005627.xml'),
 PosixPath('/home/sean/data/phone/SMSBackups/calls-20210512161412.xml'))
 ```

 (yes, I only have two files that match, recently removed duplicates)

For context:

I don't sync my entire data directory onto my phone for space concern reasons -- just a subset in ~/data/phone, which includes things like gpslogger or smsbackuprestore files.

`~/data/SMSBackups/` includes old backups I don't want to continue to sync across onto my phone, I move those off periodically
