### PR TITLE
core: add tmp_dir for global access to a tmp dir

### DIFF
--- a/my/core/core_config.py
+++ b/my/core/core_config.py
@@ -82,8 +82,7 @@ class Config(user_config):
         else:
             tpath = Path(tdir)
         tpath = tpath.expanduser()
-        if not tpath.exists():
-            tpath.mkdir(parents=True)
+        tpath.mkdir(parents=True, exist_ok=True)
         return tpath
 
     def _is_module_active(self, module: str) -> Optional[bool]:

--- a/my/core/core_config.py
+++ b/my/core/core_config.py
@@ -42,6 +42,14 @@ class Config(user_config):
     NOTE: you shouldn't use this attribute in HPI modules directly, use Config.get_cache_dir()/cachew.cache_dir() instead
     '''
 
+    tmp_dir: Optional[PathIsh] = None
+    '''
+    Path to a temporary directory.
+    This can be used temporarily while extracting zipfiles etc...
+    - if None             , uses default determined by tempfile.gettempdir + 'HPI'
+    - otherwise           , use the specified directory as the base temporary directory
+    '''
+
     enabled_modules : Optional[Sequence[str]] = None
     '''
     list of regexes/globs
@@ -62,7 +70,21 @@ class Config(user_config):
             from .cachew import _appdirs_cache_dir
             return _appdirs_cache_dir()
         else:
-            return Path(cdir)
+            return Path(cdir).expanduser()
+
+    def get_tmp_dir(self) -> Path:
+        tdir: Optional[PathIsh] = self.tmp_dir
+        tpath: Path
+        # use tempfile if unset
+        if tdir is None:
+            import tempfile
+            tpath = Path(tempfile.gettempdir()) / 'HPI'
+        else:
+            tpath = Path(tdir)
+        tpath = tpath.expanduser()
+        if not tpath.exists():
+            tpath.mkdir(parents=True)
+        return tpath
 
     def _is_module_active(self, module: str) -> Optional[bool]:
         # None means the config doesn't specify anything


### PR DESCRIPTION
This just adds the tmp_dir attribute so other
HPI modules which want access to some
temporary directory can access this safely
and the user is able to configure this

also added an expanduser() to cache_dir, incase
the user specified something like "~/.cache/",
considering most other uses of PathIsh allow
tildes

discussed this a while back on zulip:
https://memex.zulipchat.com/#narrow/stream/279601-hpi/topic/my.2Ediscord.20.2F.20processing.20archived.20data/near/235445377
