### PR TITLE
my.core.serialize: simplejson support, more types

### DIFF
--- a/tests/serialize_simplejson.py
+++ b/tests/serialize_simplejson.py
@@ -19,5 +19,5 @@ def test_simplejson_fallback() -> None:
 
     # simplejson should serialize namedtuple properly
     res: str = dumps(_A(x=1, y=2.0))
-    assert jsn.loads(res) == {"x": 1, "y": 2.0}
+    assert json.loads(res) == {"x": 1, "y": 2.0}
 

--- a/tests/serialize_simplejson.py
+++ b/tests/serialize_simplejson.py
@@ -1,0 +1,23 @@
+'''
+This file should only run when simplejson is installed,
+but orjson is not installed to check compatability
+'''
+
+# none of these should fail
+
+import json
+import simplejson
+import pytest
+
+from my.core.serialize import dumps, _A
+
+def test_simplejson_fallback() -> None:
+
+    # should fail to import
+    with pytest.raises(ModuleNotFoundError):
+        import orjson
+
+    # simplejson should serialize namedtuple properly
+    res: str = dumps(_A(x=1, y=2.0))
+    assert jsn.loads(res) == {"x": 1, "y": 2.0}
+

--- a/tox.ini
+++ b/tox.ini
@@ -23,6 +23,13 @@ commands =
 setenv = MY_CONFIG = nonexistent
 commands =
     pip install -e .[testing]
+
+    # installed to test my.core.serialize while using simplejson and not orjson
+    pip install simplejson
+    python3 -m pytest \
+                      tests/serialize_simplejson.py \
+                      {posargs}
+
     pip install cachew
     pip install orjson
 
@@ -43,7 +50,9 @@ commands =
     python3 -m pytest tests \
             # ignore some tests which might take a while to run on ci..
             --ignore tests/takeout.py        \
-            --ignore tests/extra/polar.py
+            --ignore tests/extra/polar.py \
+            # dont run simplejson compatability test since orjson is now installed
+            --ignore tests/serialize_simplejson.py
             {posargs}
 
 


### PR DESCRIPTION
I added a couple extra checks to the default function,
serializing datetime, dates and dataclasses (incase
orjson isn't installed)

(copied from below)

if orjson couldn't be imported, try simplejson
This is included for compatibility reasons because orjson
is rust-based and compiling on rarer architectures may not work
out of the box

as an example, I've been having issues getting it to install
on my phone (termux/android)

unlike the builtin JSON modue which serializes NamedTuples as lists
(even if you provide a default function), simplejson correctly
serializes namedtuples to dictionaries

this just gives another option to people, simplejson is pure python
so no one should have issues with that. (and often they already have
it installed since its used in older python projects for compatability)
orjson is still way faster, so still preferable if its easy and
theres a precompiled build for your architecture (which there typically is)

If you're ever running this with simplejson installed and not orjson,
its pretty easy to tell as the JSON styling is different; orjson has
no spaces between tokens, simplejson puts spaces between tokens. e.g.

```
simplejson: {"a": 5, "b": 10}
orjson: {"a":5,"b":10}
```