### PR TITLE
cli/query: allow querying dynamic functions

### DIFF
--- a/my/core/query.py
+++ b/my/core/query.py
@@ -54,15 +54,11 @@ def locate_function(module_name: str, function_name: str) -> Callable[[], Iterab
         for (fname, func) in inspect.getmembers(mod, inspect.isfunction):
             if fname == function_name:
                 return func
-        try:
-            # incase the function is defined dynamically,
-            # like with a globals().setdefault(...) or a module-level __getattr__ function
-            func = getattr(mod, function_name)
-            if callable(func):
-                return func
-        except AttributeError:
-            # shouldn't raise an error here, just fall through
-            pass
+        # incase the function is defined dynamically,
+        # like with a globals().setdefault(...) or a module-level __getattr__ function
+        func = getattr(mod, function_name, None)
+        if func is not None and callable(func):
+            return func
     except Exception as e:
         raise QueryException(str(e))
     raise QueryException(f"Could not find function '{function_name}' in '{module_name}'")

--- a/my/core/query.py
+++ b/my/core/query.py
@@ -54,6 +54,15 @@ def locate_function(module_name: str, function_name: str) -> Callable[[], Iterab
         for (fname, func) in inspect.getmembers(mod, inspect.isfunction):
             if fname == function_name:
                 return func
+        try:
+            # incase the function is defined dynamically,
+            # like with a globals().setdefault(...) or a module-level __getattr__ function
+            func = getattr(mod, function_name)
+            if callable(func):
+                return func
+        except AttributeError:
+            # shouldn't raise an error here, just fall through
+            pass
     except Exception as e:
         raise QueryException(str(e))
     raise QueryException(f"Could not find function '{function_name}' in '{module_name}'")


### PR DESCRIPTION
As an example of what this could be used for, I keep track of my food here,
https://github.com/seanbreckenridge/ttally/blob/master/ttally/funcs.py

While developing modules for promnesia I realized that
hpi query could be used in any module where you have a top
level function with no arguments which produces some output, and my [HPI body file](https://github.com/seanbreckenridge/HPI/blob/ce9a2f325f096a274fb074d164f7932556716c1b/my/body.py) is just annoying boilerplate that otherwise doesnt need to exist

This does a `getattr` on the module object with the function name, in case there's something in
`globals().setdefault(...)` that resolves the attribute name, or something
like a module-level `__getattr__` which resolves the function name

Doesn't break any existing functionality as this is an edge case where query
might benefit, the default of inspecting the module and filtering for functions
is still done before this `getattr` check