### PR TITLE
twitter/archive: update deprecated imports

### DIFF
--- a/my/twitter/archive.py
+++ b/my/twitter/archive.py
@@ -18,7 +18,8 @@ except ImportError as e:
 
 
 from dataclasses import dataclass
-from ..core import Paths, Res, datetime_aware
+from ..core.common import Paths, datetime_aware
+from ..core.error import Res
 
 @dataclass
 class twitter_archive(user_config):
@@ -36,12 +37,12 @@ from typing import List, Optional, NamedTuple, Sequence, Iterator
 from pathlib import Path
 import json
 
-from ..common import get_files, LazyLogger, Json
+from ..core.common import get_files, LazyLogger, Json
 from ..core import kompress
 
 
 
-logger = LazyLogger(__name__)
+logger = LazyLogger(__name__, level="debug")
 
 
 def inputs() -> Sequence[Path]:

--- a/my/twitter/archive.py
+++ b/my/twitter/archive.py
@@ -42,7 +42,7 @@ from ..core import kompress
 
 
 
-logger = LazyLogger(__name__, level="debug")
+logger = LazyLogger(__name__, level="warning")
 
 
 def inputs() -> Sequence[Path]:


### PR DESCRIPTION
while setting up twitter/archive, this sends
the deprecation warnings that my.core.__init__.py
isn't supported anymore -- just updating those
to use .common

Edit; Oh, also set the logger to debug