### PR TITLE
core/source: use import error

### DIFF
--- a/my/core/error.py
+++ b/my/core/error.py
@@ -150,6 +150,25 @@ def error_to_json(e: Exception) -> Json:
     return {'error': estr}
 
 
+def warn_my_config_import_error(err: ImportError) -> None:
+    """
+    If the user tried to import something from my.config but it failed,
+    possibly due to missing the config block in my.config?
+    """
+    import re
+    import click
+    if err.name != 'my.config':
+        return
+    # parse name that user attempted to import
+    em = re.match(r"cannot import name '(\w+)' from 'my.config'", str(err))
+    if em is not None:
+        section_name = em.group(1)
+        click.echo(click.style(f"""\
+   You may be missing the '{section_name}' section from your config.
+   See https://github.com/karlicoss/HPI/blob/master/doc/SETUP.org#private-configuration-myconfig\
+""", fg='yellow'), err=True)
+
+
 def test_datetime_errors() -> None:
     import pytz
     dt_notz = datetime.now()

--- a/my/core/source.py
+++ b/my/core/source.py
@@ -43,7 +43,7 @@ def import_source(
             try:
                 res = factory_func(**kwargs)
                 yield from res
-            except ModuleNotFoundError:
+            except ImportError:
                 from . import core_config as CC
                 suppressed_in_conf = False
                 if module_name is not None and CC.config._is_module_active(module_name) is False:

--- a/my/core/source.py
+++ b/my/core/source.py
@@ -54,7 +54,7 @@ def import_source(
                         medium(f"Module {factory_func.__qualname__} could not be imported, or isn't configured properly")
                     else:
                         medium(f"Module {module_name} ({factory_func.__qualname__}) could not be imported, or isn't configured properly")
-                        warn("""To hide this message, add {module_name} to your core config disabled_classes, like:
+                        warn(f"""To hide this message, add {module_name} to your core config disabled_classes, like:
 
 class core:
     disabled_modules = [{repr(module_name)}]

--- a/my/core/source.py
+++ b/my/core/source.py
@@ -4,7 +4,7 @@ and yielding nothing (or a default) when its not available
 """
 
 from typing import Any, Iterator, TypeVar, Callable, Optional, Iterable, Any
-from my.core.warnings import warn
+from my.core.warnings import medium, warn
 from functools import wraps
 
 # The factory function may produce something that has data
@@ -43,20 +43,26 @@ def import_source(
             try:
                 res = factory_func(**kwargs)
                 yield from res
-            except ImportError:
+            except ImportError as err:
                 from . import core_config as CC
+                from .error import warn_my_config_import_error
                 suppressed_in_conf = False
                 if module_name is not None and CC.config._is_module_active(module_name) is False:
                     suppressed_in_conf = True
                 if not suppressed_in_conf:
                     if module_name is None:
-                        warn(f"Module {factory_func.__qualname__} could not be imported, or isn't configured properly")
+                        medium(f"Module {factory_func.__qualname__} could not be imported, or isn't configured properly")
                     else:
-                        warn(f"""Module {module_name} ({factory_func.__qualname__}) could not be imported, or isn't configured properly\nTo hide this message, add {module_name} to your core config disabled_classes, like:
+                        medium(f"Module {module_name} ({factory_func.__qualname__}) could not be imported, or isn't configured properly")
+                        warn("""To hide this message, add {module_name} to your core config disabled_classes, like:
 
 class core:
     disabled_modules = [{repr(module_name)}]
 """)
+                    # explicitly check if this is a ImportError, and didn't fail
+                    # due to a module not being installed
+                    if type(err) == ImportError:
+                        warn_my_config_import_error(err)
                 yield from default
         return wrapper
     return decorator


### PR DESCRIPTION
uses the more broad ImportError
instead of ModuleNotFoundError

reasoning being if some submodule
(the one I'm configuring currently is
my.twitter.twint) doesn't have additional
imports from another parser/DAL, but it
still has a config block, the user would
have to create a stub-config block in their
config to use the all.py file

I had originally made this ModuleNotFoundError
since reddit had pushshift_comment_export,
so the assumption was that there was an additional
module that could make this fail when additional
sources are used, but that ignores this case when
its just a single file module, not calling out
to some library to handle parsing
