### PR TITLE
docs: add link to template

### DIFF
--- a/README.org
+++ b/README.org
@@ -723,6 +723,7 @@ Other HPI Repositories:
 - [[https://github.com/seanbreckenridge/HPI][seanbreckenridge/HPI]]
 - [[https://github.com/madelinecameron/hpi][madelinecameron/HPI]]
 
+If you want to create your own to create your own modules/override something here, you can use the [[https://github.com/seanbreckenridge/HPI-template][template]].
 
 * Related links
 :PROPERTIES:

--- a/doc/MODULE_DESIGN.org
+++ b/doc/MODULE_DESIGN.org
@@ -127,7 +127,7 @@ If you install both directories as editable packages (which has the benefit of a
 
 There is no limit to how many directories you could install into a single namespace package, which could be a possible way for people to install additional HPI modules, without worrying about the module count here becoming too large to manage.
 
-There are some other users [[https://github.com/hpi/hpi][who have begun publishing their own modules]] as namespace packages, which you could potentially install and use, in addition to this repository, if any of those interest you.
+There are some other users [[https://github.com/hpi/hpi][who have begun publishing their own modules]] as namespace packages, which you could potentially install and use, in addition to this repository, if any of those interest you. If you want to create your own you can use the [[https://github.com/seanbreckenridge/HPI-template][template]] to get started.
 
 Though, enabling this many modules may make ~hpi doctor~ look pretty busy. You can explicitly choose to enable/disable modules with a list of modules/regexes in your [[https://github.com/karlicoss/HPI/blob/f559e7cb899107538e6c6bbcf7576780604697ef/my/core/core_config.py#L24-L55][core config]], see [[https://github.com/seanbreckenridge/dotfiles/blob/a1a77c581de31bd55a6af3d11b8af588614a207e/.config/my/my/config/__init__.py#L42-L72][here]] for an example.
 


### PR DESCRIPTION
created a cookiecutter template to create a basic structure which supports installing into `my`

https://github.com/seanbreckenridge/HPI-template

Has two basic example modules with/without the typical module boilerplate

https://github.com/seanbreckenridge/HPI-template/tree/master/HPI-%7B%7B%20cookiecutter.username%20%7D%7D/my
