### PR TITLE
core/cli: autocomplete module names

### DIFF
--- a/misc/completion/README.md
+++ b/misc/completion/README.md
@@ -8,7 +8,7 @@ eval "$(_HPI_COMPLETE=zsh_source hpi)"  # in ~/.zshrc
 eval "$(_HPI_COMPLETE=fish_source hpi)"  # in ~/.config/fish/config.fish
 ```
 
-That is slightly slower since its generating the completion code on the fly -- see [click docs](https://click.palletsprojects.com/en/8.0.x/shell-completion/?highlight=completion#enabling-completion) for more info
+That is slightly slower since its generating the completion code on the fly -- see [click docs](https://click.palletsprojects.com/en/8.0.x/shell-completion/#enabling-completion) for more info
 
 To use the completions here:
 
@@ -32,4 +32,4 @@ If your zsh configuration doesn't automatically run `compinit`, after modifying 
 
 ### fish
 
-`cp ./fish/hpi.fish ~/.config/fish/completions/`, an then restart your shell
+`cp ./fish/hpi.fish ~/.config/fish/completions/`, then restart your shell

--- a/misc/completion/bash/_hpi
+++ b/misc/completion/bash/_hpi
@@ -8,10 +8,10 @@ _hpi_completion() {
         IFS=',' read type value <<< "$completion"
 
         if [[ $type == 'dir' ]]; then
-            COMREPLY=()
+            COMPREPLY=()
             compopt -o dirnames
         elif [[ $type == 'file' ]]; then
-            COMREPLY=()
+            COMPREPLY=()
             compopt -o default
         elif [[ $type == 'plain' ]]; then
             COMPREPLY+=($value)

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ INSTALL_REQUIRES = [
     'appdirs',        # very common, and makes it portable
     'more-itertools', # it's just too useful and very common anyway
     'decorator'     , # less pain in writing correct decorators. very mature and stable, so worth keeping in core
-    'click'         , # for the CLI, printing colors, decorator-based - may allow extensions to CLI
+    'click>=8.0'    , # for the CLI, printing colors, decorator-based - may allow extensions to CLI
 ]
 
 


### PR DESCRIPTION
* autocomplete module names for click completion (can hit TAB when typing a module and it lists choices)
* sync new bash completion file (was a bug/typo `click<8.4`)
* bump required click version to support shell completion (was a major rewrite in click 8.0, older versions may not work)
