### PR TITLE
core/source: fix error message, force kwargs for decorator

### DIFF
--- a/my/core/source.py
+++ b/my/core/source.py
@@ -42,7 +42,7 @@ def import_source(
         @wraps(factory_func)
         def wrapper(*args, **kwargs) -> Iterator[T]:
             try:
-                res = factory_func(**kwargs)
+                res = factory_func(*args, **kwargs)
                 yield from res
             except ImportError as err:
                 from . import core_config as CC

--- a/my/core/source.py
+++ b/my/core/source.py
@@ -22,6 +22,7 @@ _DEFAULT_ITR = ()
 # tried to use decorator module but it really doesn't work well
 # with types and kw-arguments... :/
 def import_source(
+    *,
     default: Iterable[T] = _DEFAULT_ITR,
     module_name: Optional[str] = None,
 ) -> Callable[..., Callable[..., Iterator[T]]]:
@@ -54,7 +55,7 @@ def import_source(
                         medium(f"Module {factory_func.__qualname__} could not be imported, or isn't configured properly")
                     else:
                         medium(f"Module {module_name} ({factory_func.__qualname__}) could not be imported, or isn't configured properly")
-                        warn(f"""To hide this message, add {module_name} to your core config disabled_classes, like:
+                        warn(f"""To hide this message, add {module_name} to your core config disabled_modules, like:
 
 class core:
     disabled_modules = [{repr(module_name)}]


### PR DESCRIPTION
typically its only getting `module_name` passed, and the
`default` is left to be `()`, so this should minimize possible
overwriting `default` with the `module_name` while developing

also fixed typo in the error text, and pass both `args` and `kwargs` to the wrapped function
