### PR TITLE
doctor: better quick option propogation for stats

### DIFF
--- a/doc/MODULES.org
+++ b/doc/MODULES.org
@@ -189,6 +189,10 @@ For an extensive/complex example, you can check out ~@seanbreckenridge~'s [[http
                # less precise, but faster
                fast: bool = True
 
+               # sort locations by date
+               # incase multiple sources provide them out of order
+               sort_locations: bool = True
+
                # if the accuracy for the location is more than 5km (this
                # isn't an accurate location, so shouldn't use it to determine
                # timezone), don't use

--- a/my/config.py
+++ b/my/config.py
@@ -84,6 +84,7 @@ class time:
     class tz:
         class via_location:
             fast: bool
+            sort_locations: bool
             require_accuracy: float
 
 

--- a/my/core/__main__.py
+++ b/my/core/__main__.py
@@ -219,7 +219,7 @@ def modules_check(*, verbose: bool, list_all: bool, quick: bool, for_modules: Li
 
     import contextlib
 
-    from .common import with_quick_stats
+    from .common import quick_stats
     from .util import get_stats, HPIModule
     from .stats import guess_stats
     from .error import warn_my_config_import_error
@@ -263,7 +263,7 @@ def modules_check(*, verbose: bool, list_all: bool, quick: bool, for_modules: Li
             # todo point to a readme on the module structure or something?
             continue
 
-        quick_context = with_quick_stats() if quick else contextlib.nullcontext()
+        quick_context = quick_stats() if quick else contextlib.nullcontext()
 
         try:
             kwargs = {}

--- a/my/core/common.py
+++ b/my/core/common.py
@@ -427,7 +427,7 @@ def warn_if_empty(f):
 
 
 # global state that turns on/off quick stats
-# can use the 'with_quick_stats' contextmanager
+# can use the 'quick_stats' contextmanager
 # to enable/disable this in cli so that module 'stats'
 # functions don't have to implement custom 'quick' logic
 QUICK_STATS = False
@@ -437,11 +437,14 @@ QUICK_STATS = False
 # elsewhere -- can use this decorator instead of editing
 # the global state directly
 @contextmanager
-def with_quick_stats():
+def quick_stats():
     global QUICK_STATS
-    prev, QUICK_STATS = QUICK_STATS, True
-    yield
-    QUICK_STATS = prev
+    prev = QUICK_STATS
+    try:
+        QUICK_STATS = True
+        yield
+    finally:
+        QUICK_STATS = prev
 
 
 C = TypeVar('C')

--- a/my/core/stats.py
+++ b/my/core/stats.py
@@ -13,12 +13,12 @@ from .common import StatsFun, Stats, stat
 
 # TODO maybe could be enough to annotate OUTPUTS or something like that?
 # then stats could just use them as hints?
-def guess_stats(module_name: str) -> Optional[StatsFun]:
+def guess_stats(module_name: str, quick: bool=False) -> Optional[StatsFun]:
     providers = guess_data_providers(module_name)
     if len(providers) == 0:
         return None
     def auto_stats() -> Stats:
-        return {k: stat(v) for k, v in providers.items()}
+        return {k: stat(v, quick=quick) for k, v in providers.items()}
     return auto_stats
 
 

--- a/my/core/util.py
+++ b/my/core/util.py
@@ -20,7 +20,7 @@ def get_stats(module: str) -> Optional[StatsFun]:
     # todo detect via ast?
     try:
         mod = import_module(module)
-    except Exception as e:
+    except Exception:
         return None
 
     return getattr(mod, 'stats', None)


### PR DESCRIPTION
* use contextmanager for quick stats instead of editing global state directly
* send quick to lots of stat related functions, so they could possibly be used without doctor, if someone wanted to
* if a stats function has a 'quick' kwarg, send the value there as well
* add an option to sort locations in my.time.tz.via_location
