### PR TITLE
zulip: add stats function

### DIFF
--- a/my/zulip/organization.py
+++ b/my/zulip/organization.py
@@ -170,3 +170,11 @@ def messages() -> Iterator[Res[Message]]:
             )
             continue
         assert_never(x)
+
+
+from my.core import Stats
+def stats() -> Stats:
+    from my.core import stat
+    return {
+        **stat(messages)
+    }


### PR DESCRIPTION
mostly so that this is included in `hpi doctor` output, since it having the stats func means its detected as a module
