### PR TITLE
allow installing modules in bulk, add experimental --parallel flag

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -91,26 +91,27 @@ commands =
 commands =
     pip install -e .[testing,optional]
 
-    hpi module install my.browser.export
-    hpi module install my.orgmode
-    hpi module install my.endomondo
-    hpi module install my.github.ghexport
-    hpi module install my.hypothesis
-    hpi module install my.instapaper
-    hpi module install my.pocket
-    hpi module install my.reddit.rexport
-    hpi module install my.reddit.pushshift
-    hpi module install my.stackexchange.stexport
-    hpi module install my.tinder.android
-    hpi module install my.pinboard
-    hpi module install my.arbtt
-    hpi module install my.coding.commits
-    hpi module install my.goodreads
-    hpi module install my.pdfs
-    hpi module install my.smscalls
-    hpi module install my.location.gpslogger
-    hpi module install my.location.via_ip
-    hpi module install my.google.takeout.parser
+    hpi module install --parallel                \
+                       my.browser.export         \
+                       my.orgmode                \
+                       my.endomondo              \
+                       my.github.ghexport        \
+                       my.hypothesis             \
+                       my.instapaper             \
+                       my.pocket                 \
+                       my.reddit.rexport         \
+                       my.reddit.pushshift       \
+                       my.stackexchange.stexport \
+                       my.tinder.android         \
+                       my.pinboard               \
+                       my.arbtt                  \
+                       my.coding.commits         \
+                       my.goodreads              \
+                       my.pdfs                   \
+                       my.smscalls               \
+                       my.location.gpslogger     \
+                       my.location.via_ip        \
+                       my.google.takeout.parser
 
     # todo fuck. -p my.github isn't checking the subpackages?? wtf...
     # guess it wants .pyi file??


### PR DESCRIPTION
`time tox -e mypy-misc` (removed the actual mypy call)

before (each module in a separate 'hpi install' command)
```
real	1m45.901s
user	1m19.555s
sys	0m5.491s
```

in a single 'hpi install' command (multiple modules)
```
real	1m31.252s
user	1m6.028s
sys	0m5.065s
```


single 'hpi install' command with --parallel
```
real	0m15.674s
user	0m50.986s
sys	0m3.249s
```

Almost 8x speedup!

Sadly doesn't help that much with github actions times, perhaps because the runner only has one core

before
```
2022-06-05T21:32:06.8525970Z mypy-misc create: /home/runner/work/HPI/HPI/.tox/mypy-misc
2022-06-05T21:34:51.3006446Z Success: no issues found in 35 source files
```

after
```
2022-06-05T23:06:25.8043510Z mypy-misc create: /home/runner/work/HPI/HPI/.tox/mypy-misc
2022-06-05T23:08:35.6433602Z Success: no issues found in 35 source files
```