### PR TITLE
source: propogate help url for config errors

### DIFF
--- a/my/core/error.py
+++ b/my/core/error.py
@@ -155,7 +155,7 @@ def error_to_json(e: Exception) -> Json:
 
 MODULE_SETUP_URL = 'https://github.com/karlicoss/HPI/blob/master/doc/SETUP.org#private-configuration-myconfig'
 
-def warn_my_config_import_error(err: Union[ImportError, AttributeError], help_url: str = MODULE_SETUP_URL) -> bool:
+def warn_my_config_import_error(err: Union[ImportError, AttributeError], help_url: Optional[str] = None) -> bool:
     """
     If the user tried to import something from my.config but it failed,
     possibly due to missing the config block in my.config?
@@ -164,6 +164,8 @@ def warn_my_config_import_error(err: Union[ImportError, AttributeError], help_ur
     """
     import re
     import click
+    if help_url is None:
+        help_url = MODULE_SETUP_URL
     if type(err) == ImportError:
         if err.name != 'my.config':
             return False

--- a/my/core/source.py
+++ b/my/core/source.py
@@ -27,6 +27,7 @@ def import_source(
     *,
     default: Iterable[T] = _DEFAULT_ITR,
     module_name: Optional[str] = None,
+    help_url: Optional[str] = None,
 ) -> Callable[..., Callable[..., Iterator[T]]]:
     """
     doesn't really play well with types, but is used to catch
@@ -64,7 +65,7 @@ class core:
 """)
                     # try to check if this is a config error or based on dependencies not being installed
                     if isinstance(err, (ImportError, AttributeError)):
-                        matched_config_err = warn_my_config_import_error(err)
+                        matched_config_err = warn_my_config_import_error(err, help_url=help_url)
                         # if we determined this wasn't a config error, and it was an attribute error
                         # it could be *any* attribute error -- we should raise this since its otherwise a fatal error
                         # from some code in the module failing


### PR DESCRIPTION
This lets users pass custom help URLs for `import_source`, so e.g. me pass my configuration for mail modules I could point them to my [mail troubleshooting docs](https://github.com/seanbreckenridge/HPI/blob/master/doc/MAIL_SETUP.md)
