### PR TITLE
core: allow legacy modules to be used in 'hpi module install' for backwards compatibility

### DIFF
--- a/misc/check_legacy_init_py.py
+++ b/misc/check_legacy_init_py.py
@@ -12,7 +12,7 @@ import logzero # type: ignore[import]
 logger = logzero.logger
 
 
-MSG = 'importing my.fbmessenger is DEPRECATED'
+MSG = 'my.fbmessenger is DEPRECATED'
 
 def expect(*cmd: str, should_warn: bool=True) -> None:
     res = run(cmd, stderr=PIPE)
@@ -61,6 +61,7 @@ check_warn('-c', 'from   my.fbmessenger import *')
 check_warn('-c', 'from   my.fbmessenger import messages, dump_chat_history')
 check_warn('-m', 'my.core', 'query' , 'my.fbmessenger.messages', '-o', 'pprint', '--limit=10')
 check_warn('-m', 'my.core', 'doctor', 'my.fbmessenger')
+check_warn('-m', 'my.core', 'module', 'requires', 'my.fbmessenger')
 
 # todo kinda annoying it doesn't work when executed as -c (but does as script!)
 # presumably because doesn't have proper line number information?
@@ -71,6 +72,7 @@ check_ok  ('-c', 'from   my.fbmessenger.export import *')
 check_ok  ('-c', 'from my.fbmessenger.export import messages, dump_chat_history')
 check_ok  ('-m', 'my.core', 'query' , 'my.fbmessenger.export.messages', '-o', 'pprint', '--limit=10')
 check_ok  ('-m', 'my.core', 'doctor', 'my.fbmessenger.export')
+check_ok  ('-m', 'my.core', 'module', 'requires', 'my.fbmessenger.export')
 
 # NOTE:
 # to check that overlays work, run something like

--- a/my/core/__main__.py
+++ b/my/core/__main__.py
@@ -339,6 +339,9 @@ def _requires(modules: Sequence[str]) -> Sequence[str]:
     mods = [module_by_name(module) for module in modules]
     res = []
     for mod in mods:
+        if mod.legacy is not None:
+            warning(mod.legacy)
+
         reqs = mod.requires
         if reqs is None:
             error(f"Module {mod.name} has no REQUIRES specification")


### PR DESCRIPTION
but show warning

kinda hacky, but hopefully we will simplify it further when we have more such legacy modules