### PR TITLE
google.takeout.parser: recreate cache on upgrade

### DIFF
--- a/my/core/__main__.py
+++ b/my/core/__main__.py
@@ -376,7 +376,9 @@ def module_install(*, user: bool, module: Sequence[str], parallel: bool=False) -
     ]
 
     cmds = []
-    if parallel:
+    # disable parallel on windows, sometimes throws a
+    # '[WinError 32] The process cannot access the file because it is being used by another process'
+    if parallel and sys.platform not in ['win32', 'cygwin']:
         # todo not really sure if it's safe to install in parallel like this
         # but definitely doesn't hurt to experiment for e.g. mypy pipelines
         # pip has '--use-feature=fast-deps', but it doesn't really work

--- a/my/google/takeout/parser.py
+++ b/my/google/takeout/parser.py
@@ -27,6 +27,7 @@ from my.core.time import user_forced
 from google_takeout_parser.parse_html.html_time_utils import ABBR_TIMEZONES
 ABBR_TIMEZONES.extend(user_forced())
 
+import google_takeout_parser
 from google_takeout_parser.path_dispatch import TakeoutParser
 from google_takeout_parser.merge import GoogleEventSet, CacheResults
 
@@ -75,8 +76,13 @@ EXPECTED = (
 )
 
 
+google_takeout_version = str(getattr(google_takeout_parser, '__version__', 'unknown'))
+
 def _cachew_depends_on() -> List[str]:
-    return sorted([str(p) for p in inputs()])
+    exports = sorted([str(p) for p in inputs()])
+    # add google takeout parser pip version to hash, so this re-creates on breaking changes
+    exports.insert(0, f"google_takeout_version: {google_takeout_version}")
+    return exports
 
 
 # ResultsType is a Union of all of the models in google_takeout_parser


### PR DESCRIPTION
Related PR in `google_takeout_parser`: https://github.com/seanbreckenridge/google_takeout_parser/pull/37

Whenever the `google_takeout_parser` pip version changes, the hash changes, so it recomputes

Went with the basic solution of prepending the google takeout pip version to the `depends_on` (though could be changed to whatever in the future if cachew exposes a version kwarg to store in that table instead)
