### PR TITLE
ci: fix tox config

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
 minversion = 3.5
+envlist = tests-core,tests-all,demo,mypy-core,mypy-misc
 # https://github.com/tox-dev/tox/issues/20#issuecomment-247788333
 # hack to prevent .tox from crapping to the project directory
 toxworkdir={env:TOXWORKDIR_BASE:}{toxinidir}/.tox
@@ -7,9 +8,11 @@ toxworkdir={env:TOXWORKDIR_BASE:}{toxinidir}/.tox
 [testenv]
 passenv = 
 # useful for tests to know they are running under ci
-  CI CI_*
+  CI
+  CI_*
 # respect user's cache dirs to prevent tox from crapping into project dir
-  MYPY_CACHE_DIR PYTHONPYCACHEPREFIX
+  MYPY_CACHE_DIR
+  PYTHONPYCACHEPREFIX
 
 
 # just the very core tests with minimal dependencies


### PR DESCRIPTION
seems that after version 4.0 it's necessary to specify environments to run previosly it was picking them up automatically