### PR TITLE
cli completion doc updates, hide legacy import warning

### DIFF
--- a/doc/SETUP.org
+++ b/doc/SETUP.org
@@ -193,6 +193,8 @@ If you only have a few modules set up, lots of them will error for you, which is
 
 If you're having issues with ~cachew~ or want to show logs to troubleshoot what may be happening, you can pass the debug flag (e.g., ~hpi --debug doctor my.module_name~) or set the ~HPI_LOGS~ environment variable (e.g., ~HPI_LOGS=debug hpi query my.module_name~) to print all logs, including the ~cachew~ dependencies. ~HPI_LOGS~ could also be used to silence ~info~ logs, like ~HPI_LOGS=warning hpi ...~
 
+If you want ~HPI~ to autocomplete the module names for you, this comes with shell completion, see [[../misc/completion/][misc/completion]]
+
 If you have any ideas on how to improve it, please let me know!
 
 Here's a screenshot how it looks when everything is mostly good: [[https://user-images.githubusercontent.com/291333/82806066-f7dfe400-9e7c-11ea-8763-b3bee8ada308.png][link]].

--- a/misc/completion/README.md
+++ b/misc/completion/README.md
@@ -10,21 +10,23 @@ eval "$(_HPI_COMPLETE=fish_source hpi)"  # in ~/.config/fish/config.fish
 
 That is slightly slower since its generating the completion code on the fly -- see [click docs](https://click.palletsprojects.com/en/8.0.x/shell-completion/#enabling-completion) for more info
 
-To use the completions here:
+To use the generated completion files in this repository, you need to source the file in `./bash`, `./zsh`, or `./fish` depending on your shell.
+
+If you don't have HPI cloned locally, after installing `HPI` you can generate the file yourself using one of the commands above. For example, for `bash`: `_HPI_COMPLETE=bash_source hpi > ~/.config/hpi_bash_completion`, and then source it like `source ~/.config/hpi_bash_completion`
 
 ### bash
 
-Put `source /path/to/bash/_hpi` in your `~/.bashrc`
+Put `source /path/to/hpi/repo/misc/completion/bash/_hpi` in your `~/.bashrc`
 
 ### zsh
 
 You can either source the file:
 
-`source /path/to/zsh/_hpi`
+`source /path/to/hpi/repo/misc/completion/zsh/_hpi`
 
 ..or add the directory to your `fpath` to load it lazily:
 
-`fpath=("/path/to/zsh/" "${fpath[@]}")` (Note: the directory, not the script `_hpi`)
+`fpath=("/path/to/hpi/repo/misc/completion/zsh/" "${fpath[@]}")` (Note: the directory, not the script `_hpi`)
 
 If your zsh configuration doesn't automatically run `compinit`, after modifying your `fpath` you should:
 

--- a/my/core/legacy.py
+++ b/my/core/legacy.py
@@ -1,4 +1,5 @@
 # I think 'compat' should be for python-specific compat stuff, whereas this for HPI specific backwards compatibility
+import os
 import inspect
 import re
 from typing import List
@@ -45,8 +46,12 @@ def handle_legacy_import(
         if re.match(rf'from\s+{parent_module_name}\s+import\s+{legacy_submodule_name}', line):
             importing_submodule = True
 
+    # click sets '_HPI_COMPLETE' env var when it's doing autocompletion
+    # otherwise, the warning will be printed every time you try to tab complete
+    autocompleting_module_cli = "_HPI_COMPLETE" in os.environ
+
     is_legacy_import = not (imported_as_parent or importing_submodule)
-    if is_legacy_import:
+    if is_legacy_import and not autocompleting_module_cli:
         W.high(f'''\
 importing {parent_module_name} is DEPRECATED! \
 Instead, import from {parent_module_name}.{legacy_submodule_name} or {parent_module_name}.all \


### PR DESCRIPTION
- core/cli: hide warnings when autocompleting
- link to completion in setup/troubleshooting
- update completion docs to make source path clear
