### PR TITLE
cli: add option to output locations to gpx files

### DIFF
--- a/my/core/__main__.py
+++ b/my/core/__main__.py
@@ -542,6 +542,14 @@ def query_hpi_functions(
                 pprint(item)
         else:
             pprint(list(res))
+    elif output == 'gpx':
+        from my.location.common import locations_to_gpx
+
+        # can ignore the mypy warning here, locations_to_gpx yields any errors
+        # if you didnt pass it something that matches the LocationProtocol
+        for exc in list(locations_to_gpx(res, sys.stdout)):   # type: ignore[arg-type]
+            click.echo(str(exc), err=True)
+        sys.stdout.flush()
     else:
         res = list(res)  # type: ignore[assignment]
         # output == 'repl'
@@ -681,7 +689,7 @@ def module_install_cmd(user: bool, parallel: bool, modules: Sequence[str]) -> No
 @click.option('-o',
               '--output',
               default='json',
-              type=click.Choice(['json', 'pprint', 'repl']),
+              type=click.Choice(['json', 'pprint', 'repl', 'gpx']),
               help='what to do with the result [default: json]')
 @click.option('-s',
               '--stream',

--- a/my/core/__main__.py
+++ b/my/core/__main__.py
@@ -547,7 +547,7 @@ def query_hpi_functions(
 
         # can ignore the mypy warning here, locations_to_gpx yields any errors
         # if you didnt pass it something that matches the LocationProtocol
-        for exc in list(locations_to_gpx(res, sys.stdout)):   # type: ignore[arg-type]
+        for exc in locations_to_gpx(res, sys.stdout):   # type: ignore[arg-type]
             click.echo(str(exc), err=True)
         sys.stdout.flush()
     else:

--- a/tox.ini
+++ b/tox.ini
@@ -85,6 +85,7 @@ allowlist_externals = cat
 commands =
     pip install -e .[testing,optional]
     pip install orgparse # used it core.orgmode?
+    pip install gpxpy # for hpi query --output gpx
 
     {envpython} -m mypy --install-types --non-interactive \
                     -p my.core \


### PR DESCRIPTION
This adds an `--output gpx` option to `hpi query` that will output anything that
looks like a `LocationProtocol` to GPX on stdout


Found a nice GUI tool to quickly preview GPX files: https://github.com/tumic0/GPXSee


```bash
hpi query my.location.gpslogger --recent 1w -o gpx >out.gpx; gpxsee out.gpx
```
