### PR TITLE
core/cli: update vendored completion files

### DIFF
--- a/misc/completion/fish/hpi.fish
+++ b/misc/completion/fish/hpi.fish
@@ -1,9 +1,5 @@
 function _hpi_completion;
-    set -l response;
-
-    for value in (env _HPI_COMPLETE=fish_complete COMP_WORDS=(commandline -cp) COMP_CWORD=(commandline -t) hpi);
-        set response $response $value;
-    end;
+    set -l response (env _HPI_COMPLETE=fish_complete COMP_WORDS=(commandline -cp) COMP_CWORD=(commandline -t) hpi);
 
     for completion in $response;
         set -l metadata (string split "," $completion);

--- a/misc/completion/zsh/_hpi
+++ b/misc/completion/zsh/_hpi
@@ -31,5 +31,11 @@ _hpi_completion() {
     fi
 }
 
-compdef _hpi_completion hpi;
+if [[ $zsh_eval_context[-1] == loadautofunc ]]; then
+    # autoload from fpath, call function directly
+    _hpi_completion "$@"
+else
+    # eval/source/. command, register function for later
+    compdef _hpi_completion hpi
+fi
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ INSTALL_REQUIRES = [
     'appdirs',        # very common, and makes it portable
     'more-itertools', # it's just too useful and very common anyway
     'decorator'     , # less pain in writing correct decorators. very mature and stable, so worth keeping in core
-    'click>=8.0'    , # for the CLI, printing colors, decorator-based - may allow extensions to CLI
+    'click>=8.1'    , # for the CLI, printing colors, decorator-based - may allow extensions to CLI
 ]
 
 


### PR DESCRIPTION
update the vendored completion files (click has since pushed
some updates that change the output of the completions)

update required click version to 8.1
so we dont regenerate the vendored completions
wrong in the future
