### PR TITLE
ci: use --parallel flag in tox to speed up pipelines

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 from subprocess import check_call, DEVNULL
-from shutil import copy, copytree
+from shutil import copytree, ignore_patterns
 import os
 from os.path import abspath
 from sys import executable as python
@@ -9,12 +9,17 @@ from pathlib import Path
 my_repo = Path(__file__).absolute().parent
 
 
-def run():
+def run() -> None:
     # uses fixed paths; worth it for the sake of demonstration
     # assumes we're in /tmp/my_demo now
 
     # 1. clone git@github.com:karlicoss/my.git
-    copytree(my_repo, 'my_repo', symlinks=True)
+    copytree(
+        my_repo,
+        'my_repo',
+        symlinks=True,
+        ignore=ignore_patterns('.tox*'),  # tox dir might have broken symlinks while tests are running in parallel
+    )
 
     # 2. prepare repositories you'd be using. For this demo we only set up Hypothesis
     tox = 'TOX' in os.environ

--- a/my/jawbone/__init__.py
+++ b/my/jawbone/__init__.py
@@ -115,14 +115,15 @@ def pre_dataframe() -> Iterable[Res[SleepEntry]]:
             yield group[0]
         else:
             err = RuntimeError(f'Multiple sleeps per night, not supported yet: {group}')
-            set_error_datetime(err, dt=dd)
+            set_error_datetime(err, dt=dd)  # type: ignore[arg-type]
             logger.exception(err)
             yield err
 
 
 def dataframe():
-    dicts: List[Dict] = []
+    dicts: List[Dict[str, Any]] = []
     for s in pre_dataframe():
+        d: Dict[str, Any]
         if isinstance(s, Exception):
             dt = extract_error_datetime(s)
             d = {
@@ -141,7 +142,7 @@ def dataframe():
             }
         dicts.append(d)
 
-    import pandas as pd # type: ignore
+    import pandas as pd
     return pd.DataFrame(dicts)
     # TODO tz is in sleeps json
 

--- a/my/jawbone/plots.py
+++ b/my/jawbone/plots.py
@@ -15,7 +15,7 @@ from typing import Dict, Any, NamedTuple
 #         print(line)
 
 import matplotlib.pyplot as plt # type: ignore
-from numpy import genfromtxt # type: ignore
+from numpy import genfromtxt
 import matplotlib.pylab as pylab # type: ignore
 
 pylab.rcParams['figure.figsize'] = (32.0, 24.0)
@@ -109,7 +109,7 @@ dates = [parse_date(u.date, yearfirst=True, dayfirst=False) for u in useful]
 
 # TODO don't need this anymore? it's gonna be in dashboards package
 from kython.plotting import plot_timestamped  # type: ignore
-for attr, lims, mavg, fig in [ # type: ignore
+for attr, lims, mavg, fig in [
         ('light', (0, 400), 5, None),
         ('deep', (0, 600), 5, None),
         ('total', (200, 600), 5, None),
@@ -128,7 +128,7 @@ for attr, lims, mavg, fig in [ # type: ignore
         if mavg is not None:
             mavgs.append((mavg, 'green'))
         fig = plot_timestamped(
-            dts, # type: ignore
+            dts,
             [getattr(u, attr) for u in useful],
             marker='.',
             ratio=(16, 4),

--- a/scripts/ci/run
+++ b/scripts/ci/run
@@ -38,4 +38,4 @@ if ! command -v python3 &> /dev/null; then
 fi
 
 "$PY_BIN" -m pip install --user tox
-"$PY_BIN" -m tox
+"$PY_BIN" -m tox --parallel --parallel-live "$@"

--- a/tox.ini
+++ b/tox.ini
@@ -15,10 +15,14 @@ passenv =
   PYTHONPYCACHEPREFIX
 
 
+# note: --use-pep517 below is necessary for tox --parallel flag to work properly
+# otherwise it seems that it tries to modify .eggs dir in parallel and it fails
+
+
 # just the very core tests with minimal dependencies
 [testenv:tests-core]
 commands =
-    pip install -e .[testing]
+    pip install --use-pep517 -e .[testing]
     
     # seems that denylist tests rely on it? ideally we should get rid of this in tests-core
     pip install orjson
@@ -47,7 +51,7 @@ commands =
 # TODO not sure if need it?
 setenv = MY_CONFIG = nonexistent
 commands =
-    pip install -e .[testing]
+    pip install --use-pep517 -e .[testing]
 
     # installed to test my.core.serialize while using simplejson and not orjson
     pip install simplejson
@@ -104,7 +108,7 @@ commands =
 [testenv:mypy-core]
 allowlist_externals = cat
 commands =
-    pip install -e .[testing,optional]
+    pip install --use-pep517 -e .[testing,optional]
     pip install orgparse # used it core.orgmode?
     pip install gpxpy # for hpi query --output gpx
 
@@ -121,7 +125,7 @@ commands =
 [testenv:mypy-misc]
 allowlist_externals = cat
 commands =
-    pip install -e .[testing,optional]
+    pip install --use-pep517 -e .[testing,optional]
 
     hpi module install --parallel                \
         my.arbtt                  \


### PR DESCRIPTION
This speeds github actions quite a bit -- typical time before the change was 12+ minutes, whereas now it's less than 8 minutes