### PR TITLE
tox: disable --parallel flag in hpi module install

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -134,7 +134,7 @@ commands =
 commands =
     {envpython} -m pip install --use-pep517 -e .[testing,optional]
 
-    {envpython} -m my.core module install --parallel \
+    {envpython} -m my.core module install \
         my.arbtt                  \
         my.browser.export         \
         my.coding.commits         \


### PR DESCRIPTION
It's been so flaky it ends up taking more time to merge stuff. See https://github.com/karlicoss/HPI/issues/306