### PR TITLE
gpslogger: catch broken xml file error

### DIFF
--- a/my/location/gpslogger.py
+++ b/my/location/gpslogger.py
@@ -23,6 +23,7 @@ from pathlib import Path
 from typing import Iterator, Sequence, List
 
 import gpxpy
+from gpxpy.gpx import GPXXMLSyntaxException
 from more_itertools import unique_everseen
 
 from my.core import Stats, LazyLogger
@@ -58,7 +59,11 @@ def locations() -> Iterator[Location]:
 
 def _extract_locations(path: Path) -> Iterator[Location]:
     with path.open("r") as gf:
-        gpx_obj = gpxpy.parse(gf)
+        try:
+            gpx_obj = gpxpy.parse(gf)
+        except GPXXMLSyntaxException as e:
+            logger.warning("failed to parse XML %s: %s", path, e)
+            return
         for track in gpx_obj.tracks:
             for segment in track.segments:
                 for point in segment.points:


### PR DESCRIPTION
```
File "/home/sean/.local/lib/python3.11/site-packages/gpxpy/parser.py", line 146, in parse
    raise mod_gpx.GPXXMLSyntaxException('Error parsing XML: %s' % str(e), e)
gpxpy.gpx.GPXXMLSyntaxException: Error parsing XML: Extra content at the end of the document, line 39, column 22 (<string>, line 39)
```

not sure exactly what the cause for it is, but sometimes if my laptop loses power (so it crashes) it adds a bunch of weird EOF characters to the end of the file, and this ends up breaking the parser.

I can manually fix that, just thought Id prevent any broken XML files from crashing the parser.
