### PR TITLE
google takeout: support multiple locales, resolves #330

### DIFF
--- a/my/google/takeout/parser.py
+++ b/my/google/takeout/parser.py
@@ -64,13 +64,19 @@ def inputs() -> Sequence[Path]:
     return get_files(config.takeout_path)
 
 
-EXPECTED = (
-    "My Activity",
-    "Chrome",
-    "Location History",
-    "Youtube",
-    "YouTube and YouTube Music",
-)
+try:
+    from google_takeout_parser.locales.main import get_paths_for_functions
+
+    EXPECTED = tuple(get_paths_for_functions())
+
+except ImportError:
+    EXPECTED = (
+        "My Activity",
+        "Chrome",
+        "Location History",
+        "Youtube",
+        "YouTube and YouTube Music",
+    )
 
 
 google_takeout_version = str(getattr(google_takeout_parser, '__version__', 'unknown'))


### PR DESCRIPTION
uses the known locales in google_takeout_parser
to determine the expected paths for each locale,
and performs a partial match on the paths to
detect and use match_structure

falls back to old behavior if no match is found

since google_taktoue_parser currently supports EN/DE, this looks like:

```
In [1]: import my.google.takeout
   ...: .parser
my.
In [2]: my.google.takeout.parser
   ...: .EXPECTED
Out[2]:
('Chrome',
 'Location History',
 'Meine Aktivitäten',
 'My Activity',
 'Standortverlauf',
 'YouTube( and YouTube Music)?',
 'YouTube( und YouTube Music)?')
```
