### PR TITLE
smscalls: parse mms from smscalls export

### DIFF
--- a/my/smscalls.py
+++ b/my/smscalls.py
@@ -240,9 +240,11 @@ def _extract_mms(path: Path) -> Iterator[Res[MMS]]:
                 user_type = addr_data.get('type')
                 if user_address is None or user_type is None:
                     addr_str = etree.tostring(addr_parent).decode()
-                    return RuntimeError(f'Missing one or more required attributes [address, type] in {addr_str}')
+                    yield RuntimeError(f'Missing one or more required attributes [address, type] in {addr_str}')
+                    continue
                 if not user_type.isdigit():
-                    return RuntimeError(f'Invalid type {user_type}')
+                    yield RuntimeError(f'Invalid string {user_type} {type(user_type)}, cannot convert to number')
+                    continue
                 addresses.append((user_address, int(user_type)))
 
         content: List[MMSContentPart] = []

--- a/my/smscalls.py
+++ b/my/smscalls.py
@@ -209,7 +209,9 @@ def mms() -> Iterator[Res[MMS]]:
 def _resolve_null_str(value: Optional[str]) -> Optional[str]:
     if value is None:
         return None
-    if value.lower() == 'null':
+    # hmm.. theres some risk of the text actually being 'null', but theres
+    # no way to distinguish that from XML values
+    if value == 'null':
         return None
     return value
 

--- a/my/smscalls.py
+++ b/my/smscalls.py
@@ -190,11 +190,13 @@ def _parse_mms(path: Path) -> Iterator[Res[MMS]]:
     for mxml in tr.findall('mms'):
         dt = mxml.get('date')
         dt_readable = mxml.get('readable_date')
+        message_type = mxml.get('msg_box')
+
+        # TODO: split these by `~`?
         who = mxml.get('contact_name')
         if who is not None and who in UNKNOWN:
             who = None
         phone_number = mxml.get('address')
-        message_type = mxml.get('msg_box')
 
         if dt is None or dt_readable is None or message_type is None or phone_number is None:
             mxml_str = etree.tostring(mxml).decode('utf-8')
@@ -204,13 +206,8 @@ def _parse_mms(path: Path) -> Iterator[Res[MMS]]:
 
         content: List[MMSContentPart] = []
 
-        # seems pointless, but will leave here as its how the spec describes it
-        # The addresses here are also included in 'addresses' (which also doesnt
-        # include your own address), as well as possibly contains a contact name
-        #
-        # the only difference is its a single field (split by '~' it seems?) when
-        # using the top-level attributes instead of 'addresses', but seems to be no
-        # reason to use this
+        # TODO: use this to extract out which person actually sent this
+        # message_type does not accurately encode that when there are multiple people
         #
         # addresses = []
         # for addr_parent in mxml.findall('addrs'):

--- a/my/smscalls.py
+++ b/my/smscalls.py
@@ -243,7 +243,7 @@ def _extract_mms(path: Path) -> Iterator[Res[MMS]]:
                     yield RuntimeError(f'Missing one or more required attributes [address, type] in {addr_str}')
                     continue
                 if not user_type.isdigit():
-                    yield RuntimeError(f'Invalid string {user_type} {type(user_type)}, cannot convert to number')
+                    yield RuntimeError(f'Invalid address type {user_type} {type(user_type)}, cannot convert to number')
                     continue
                 addresses.append((user_address, int(user_type)))
 
@@ -270,7 +270,7 @@ def _extract_mms(path: Path) -> Iterator[Res[MMS]]:
                     continue
 
                 if seq is None or not seq.isdigit():
-                    yield RuntimeError(f'seq must be a number, was seq={seq} in {part_data}')
+                    yield RuntimeError(f'seq must be a number, was seq={seq} {type(seq)} in {part_data}')
                     continue
 
                 charset_type: Optional[str] = _resolve_null_str(part_data.get('ct'))

--- a/my/smscalls.py
+++ b/my/smscalls.py
@@ -206,6 +206,7 @@ def mms() -> Iterator[Res[MMS]]:
             emitted.add(key)
             yield c
 
+
 def _resolve_null_str(value: Optional[str]) -> Optional[str]:
     if value is None:
         return None

--- a/tests/smscalls.py
+++ b/tests/smscalls.py
@@ -4,6 +4,7 @@ from my.tests.common import skip_if_not_karlicoss as pytestmark
 
 # TODO implement via stat?
 def test() -> None:
-    from my.smscalls import calls, messages
+    from my.smscalls import calls, messages, mms
     assert len(list(calls())) > 10
     assert len(list(messages())) > 10
+    assert len(list(mms())) > 10


### PR DESCRIPTION
parses all the MMS file/content parts, left comments alongside me exploring the data object

want to actually try consuming the output of this somewhere before I think it should be merged

also, there are some items parsed as MMS which are actually just text (like, theyre SMIL (XML-format) containers which contain a single `text/plain` file), with no pictures attached. So, its just a text thats stored in a MMS container, in an ideal world we can filter those out and add them to `messages`? But may not always work perfectly

So, we should probably at least note that mms can have text items, or... maybe combine them/have some helper `.property` methods on the `MMS` that give you nicer filtering/output?

will post some examples when I'm playing with this, gonna go sleep now

```bash
$ hpi doctor -S my.smscalls
✅ OK  : my.smscalls                                      
✅     - stats: {..... 'mms': {'count': 2491, 'first': datetime.datetime(2019, 12, 18, 4, 22, 46, tzinfo=datetime.timezone.utc), 'last': datetime.datetime(2024, 5, 29, 1, 31, 19, tzinfo=datetime.timezone.utc)}}
```