### PR TITLE
fix typo in rexport DAL

### DIFF
--- a/my/reddit/rexport.py
+++ b/my/reddit/rexport.py
@@ -146,7 +146,7 @@ if not TYPE_CHECKING:
         # here we just check that types are available, we don't actually want to import them
         # fmt: off
         dal.Subreddit  # noqa: B018
-        dal.Profile  # noqa: B018e
+        dal.Profile  # noqa: B018
         dal.Multireddit  # noqa: B018
         # fmt: on
     except AttributeError as ae:

--- a/my/reddit/rexport.py
+++ b/my/reddit/rexport.py
@@ -146,7 +146,7 @@ if not TYPE_CHECKING:
         # here we just check that types are available, we don't actually want to import them
         # fmt: off
         dal.Subreddit  # noqa: B018
-        dal.Profil  # noqa: B018e
+        dal.Profile  # noqa: B018e
         dal.Multireddit  # noqa: B018
         # fmt: on
     except AttributeError as ae:


### PR DESCRIPTION
@karlicoss was receiving this warning on a fresh install

```
/home/garg/my-data/HPI/my/reddit/rexport.py:153: UserWarning: module 'rexport.dal' has no attribute 'Profil' : please update "rexport" installation
  warnings.high(f'{ae} : please update "rexport" installation')
```

this PR fixes it