### PR TITLE
general: use Exception.add_note instead of hacky my.core.error.echain

### DIFF
--- a/src/my/core/compat.py
+++ b/src/my/core/compat.py
@@ -137,3 +137,30 @@ if sys.version_info[:2] >= (3, 11):
     from typing import Never, assert_never, assert_type
 else:
     from typing_extensions import Never, assert_never, assert_type
+
+
+if sys.version_info[:2] >= (3, 11):
+    add_note = BaseException.add_note
+else:
+
+    def add_note(e: BaseException, note: str) -> None:
+        """
+        Backport of BaseException.add_note
+        """
+
+        # The only (somewhat annoying) difference is it will log extra lines for notes past the main exception message:
+        # (i.e. line 2 here:)
+
+        # 1 [ERROR   2025-02-04 22:12:21] Main exception message
+        # 2 ^ extra note
+        # 3 Traceback (most recent call last):
+        # 4   File "run.py", line 19, in <module>
+        # 5     ee = test()
+        # 6   File "run.py", line 5, in test
+        # 7     raise RuntimeError("Main exception message")
+        # 8 RuntimeError: Main exception message
+        # 9 ^ extra note
+
+        args = e.args
+        if len(args) == 1 and isinstance(args[0], str):
+            e.args = (e.args[0] + '\n' + note,)

--- a/src/my/core/error.py
+++ b/src/my/core/error.py
@@ -75,6 +75,7 @@ def warn_exceptions(itr: Iterable[Res[T]], warn_func: Callable[[Exception], None
         yield o
 
 
+# TODO deprecate in favor of Exception.add_note?
 def echain(ex: E, cause: Exception) -> E:
     ex.__cause__ = cause
     return ex

--- a/src/my/github/gdpr.py
+++ b/src/my/github/gdpr.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import Any
 
 from my.core import Paths, Res, Stats, get_files, make_logger, stat, warnings
-from my.core.error import echain
+from my.core.compat import add_note
 
 from .common import Event, EventIds, parse_dt
 
@@ -127,7 +127,8 @@ def _process_one(root: Path) -> Iterator[Res[Event]]:
             try:
                 yield handler(r)
             except Exception as e:
-                yield echain(RuntimeError(f'While processing file: {f}'), e)
+                add_note(e, f'^ while processing {f}')
+                yield e
 
 
 def stats() -> Stats:

--- a/src/my/photos/main.py
+++ b/src/my/photos/main.py
@@ -76,7 +76,7 @@ def _make_photo(photo: Path, mtype: str, *, parent_geo: LatLon | None) -> Iterat
         try:
             exif = get_exif_from_file(photo)
         except Exception as e:
-            # TODO reuse echain from promnesia
+            # TODO add exception note?
             yield e
             exif = {}
 

--- a/src/my/whatsapp/android.py
+++ b/src/my/whatsapp/android.py
@@ -13,7 +13,8 @@ from typing import Union
 
 from my.core import Paths, Res, datetime_aware, get_files, make_config, make_logger
 from my.core.common import unique_everseen
-from my.core.error import echain, notnone
+from my.core.compat import add_note
+from my.core.error import notnone
 from my.core.sqlite import sqlite_connection
 
 import my.config  # isort: skip
@@ -222,7 +223,7 @@ def _entities() -> Iterator[Res[Entity]]:
             try:
                 yield from _process_db(db)
             except Exception as e:
-                yield echain(RuntimeError(f'While processing {path}'), cause=e)
+                add_note(e, f'^ while processing {path}')
 
 
 def entities() -> Iterator[Res[Entity]]:


### PR DESCRIPTION
before it was dumping a sequence of somewhat confusing exception messages, now it's printing something like this

```
[ERROR   2025-02-04 21:53:13,891 my.instagram.android run.py:9   ] ('<message_id>', "xma_link isn't handled yet")
Traceback (most recent call last):
  File "src/my/instagram/android.py", line 169, in _process_db
    m = _parse_message(j)
        ^^^^^^^^^^^^^^^^^
  File "/code/hpi/src/my/instagram/android.py", line 120, in _parse_message
    raise MessageError(id, f"{t} isn't handled yet")
my.instagram.android.MessageError: ('2932982394892980393664', "xma_link isn't handled yet")
^ while parsing {'status': 'UPLOADED', 'item_type': 'xma_link',...
^ while processing /path/to/db/direct.db
```

for python < 3.11, a backport is used

For more info, see:
- https://peps.python.org/pep-0678
- https://docs.python.org/3/tutorial/errors.html#tut-exception-notes