### PR TITLE
general: remove unnecessary __init__.py in tests/ subpackages

### DIFF
--- a/src/my/core/tests/__init__.py
+++ b/src/my/core/tests/__init__.py
@@ -1,3 +1,0 @@
-# hmm, sadly pytest --import-mode importlib --pyargs my.core.tests doesn't work properly without __init__.py
-# although it works if you run either my.core or my.core.tests.sqlite (for example) directly
-# so if it gets in the way could get rid of this later?

--- a/src/my/tests/__init__.py
+++ b/src/my/tests/__init__.py
@@ -1,8 +1,0 @@
-# hmm, sadly pytest --import-mode importlib --pyargs my.core.tests doesn't work properly without __init__.py
-# although it works if you run either my.core or my.core.tests.sqlite (for example) directly
-# so if it gets in the way could get rid of this later?
-
-# this particularly sucks here, because otherwise would be nice if people could also just put tests for their my. packages into their tests/ directory
-# maybe some sort of hack could be used later similar to handle_legacy_import?
-
-from my.core import __NOT_HPI_MODULE__


### PR DESCRIPTION
they aren't necessary anymore for pytest discovery since we're using conftest from here https://github.com/karlicoss/pytest_namespace_pkgs

however they are getting in the way of running mypy against the overlay