### PR TITLE
ci: bring pytest config/pyproject/tox up to date/switch to hatch for building package

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -20,11 +20,9 @@ namespace_pkg_dirs = [str(d) for d in root_dir.iterdir() if d.is_dir()]
 # resolve_package_path is called from _pytest.pathlib.import_path
 # takes a full abs path to the test file and needs to return the path to the 'root' package on the filesystem
 resolve_pkg_path_orig = _pytest.pathlib.resolve_package_path
-def resolve_package_path(path: pathlib.Path) -> Optional[pathlib.Path]:
-    if 'tests_misc/conftest.py' in str(path):
-        # ugh. otherwise it can't resolve the path since tests_misc isn't under src/ dir..
-        return resolve_pkg_path_orig(path)
 
+
+def resolve_package_path(path: pathlib.Path) -> Optional[pathlib.Path]:
     result = path  # search from the test file upwards
     for parent in result.parents:
         if str(parent) in namespace_pkg_dirs:
@@ -34,7 +32,12 @@ def resolve_package_path(path: pathlib.Path) -> Optional[pathlib.Path]:
         if path.name == 'conftest.py':
             return resolve_pkg_path_orig(path)
     raise RuntimeError("Couldn't determine path for ", path)
-_pytest.pathlib.resolve_package_path = resolve_package_path
+
+
+# NOTE: seems like it's not necessary anymore?
+# keeping it for now just in case
+# after https://github.com/pytest-dev/pytest/pull/13426 we should be able to remove the whole conftest
+# _pytest.pathlib.resolve_package_path = resolve_package_path
 
 
 # without patching, the orig function returns just a package name for some reason
@@ -42,10 +45,14 @@ _pytest.pathlib.resolve_package_path = resolve_package_path
 # so we need to point it at the absolute path properly
 # not sure what are the consequences.. maybe it wouldn't be able to run against installed packages? not sure..
 search_pypath_orig = _pytest.main.search_pypath
+
+
 def search_pypath(module_name: str) -> str:
     mpath = root_dir / module_name.replace('.', os.sep)
     if not mpath.is_dir():
         mpath = mpath.with_suffix('.py')
         assert mpath.exists(), mpath  # just in case
     return str(mpath)
+
+
 _pytest.main.search_pypath = search_pypath

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 # see https://github.com/karlicoss/pymplate for up-to-date reference
 [project]
-dynamic = ["version"]  # version is managed by setuptools_scm
+dynamic = ["version"]  # version is managed by build backend
 # NOTE: 'my' is taken for PyPi already, and makes discovering the project impossible
 #  , so we're using HPI
 name = "HPI"
@@ -47,7 +47,7 @@ optional = [
     "enlighten",  # for CLI progress bars
 ]
 
-# TODO use dependency-groups later once pip support is more mature https://github.com/pypa/pip/pull/13065
+[dependency-groups]
 testing = [
     "pytest",
     "ruff",
@@ -72,25 +72,26 @@ testing = [
 ]
 
 
-[dependency-groups]
-testing = [
-    # hack to workaround missing dependency groups support in pip while making it still work with uv
-    "hpi[testing]",
-]
-
 [project.scripts]
 hpi = "my.core.__main__:main"
-
-
-[build-system]
-requires = ["setuptools", "setuptools-scm"]
-build-backend = "setuptools.build_meta"
-
-[tool.setuptools_scm]
-version_scheme = "python-simplified-semver"
-local_scheme = "dirty-tag"
 
 # workaround for error during uv publishing
 # see https://github.com/astral-sh/uv/issues/9513#issuecomment-2519527822
 [tool.setuptools]
 license-files = []
+
+
+[build-system]
+requires = ["hatchling", "hatch-vcs"]
+build-backend = "hatchling.build"
+
+# unfortunately have to duplicate project name here atm, see https://github.com/pypa/hatch/issues/1894
+[tool.hatch.build.targets.wheel]
+packages = ["src/my"]
+
+[tool.hatch.version]
+source = "vcs"
+
+[tool.hatch.version.raw-options]
+version_scheme = "python-simplified-semver"
+local_scheme = "dirty-tag"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,15 @@
 [pytest]
 # discover files that don't follow test_ naming. Useful to keep tests along with the source code
 python_files = *.py
+
+# this setting only impacts package/module naming under pytest, not the discovery
+consider_namespace_packages = true
+
 addopts =
+  # prevent pytest cache from being created... it craps into project dir and I never use it anyway
+  -p no:cacheprovider
+
+  # -rap to print tests summary even when they are successful
   -rap
   --verbose
   # TODO hmm, not sure... guess it makes sense considering all the ext modules..

--- a/src/my/tests/pdfs.py
+++ b/src/my/tests/pdfs.py
@@ -6,7 +6,8 @@ from more_itertools import ilen
 
 from my.core.cfg import tmp_config
 from my.pdfs import annotated_pdfs, annotations, get_annots
-from my.tests.common import testdata
+
+from .common import testdata
 
 
 def test_module(with_config) -> None:

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ toxworkdir = {env:TOXWORKDIR_BASE:}{toxinidir}/.tox
 [testenv]
 # TODO how to get package name from setuptools?
 package_name = "my"
-passenv =
+pass_env =
 # useful for tests to know they are running under ci
     CI
     CI_*
@@ -17,23 +17,24 @@ passenv =
     PYTHONPYCACHEPREFIX
     MYPY_CACHE_DIR
     RUFF_CACHE_DIR
-usedevelop = true  # for some reason tox seems to ignore "-e ." in deps section??
-uv_seed = true  # seems necessary so uv creates separate venvs per tox env?
-setenv =
+
+set_env =
+# do not add current working directory to pythonpath
+# generally this is more robust and safer, prevents weird issues later on
+    PYTHONSAFEPATH=1
     HPI_MODULE_INSTALL_USE_UV=true
 
-
-# note: --use-pep517 below is necessary for tox --parallel flag to work properly
-# otherwise it seems that it tries to modify .eggs dir in parallel and it fails
+# default is 'editable', in which tox builds wheel first for some reason? not sure if makes much sense
+package = uv-editable
 
 
 [testenv:ruff]
+skip_install = true
 dependency_groups = testing
 commands =
-    {envpython} -m ruff check src/
+    {envpython} -m ruff check \
+        {posargs}
 
-# todo not sure if there's much difference between deps and extras= like here?
-# https://github.com/tox-dev/tox-uv?tab=readme-ov-file#uvlock-support
 
 # just the very core tests with minimal dependencies
 [testenv:tests-core]
@@ -89,16 +90,30 @@ commands =
 
 
 [testenv:demo]
+set_env =
+# ugh. the demo test relies on 'current' directory path, so need to undy the PYTHONSAFEPATH set above
+# the whole demo test is a bit crap, should really migrate to something more robust
+    PYTHONSAFEPATH=
+# another issue is that it's installing HPI, and then patching/ trying to use the 'local' version -- really not ideal..
+skip_install = true
 deps =
     git+https://github.com/karlicoss/hypexport
+    # copy the dependencies from pyproject.toml for now
+    pytz
+    typing-extensions
+    platformdirs
+    more-itertools
+    decorator
+    click
+    kompress
 commands =
     {envpython} ./demo.py
 
 
 [testenv:mypy-core]
 dependency_groups = testing
+extras = optional
 deps =
-    -e .[optional]
     orgparse  # for core.orgmode
     gpxpy     # for hpi query --output gpx
 commands =
@@ -114,8 +129,8 @@ commands =
 # todo maybe split into separate jobs? need to add comment how to run
 [testenv:mypy-misc]
 dependency_groups = testing
+extras = optional
 deps =
-    -e .[optional]
     uv                 # for hpi module install
     lxml-stubs         # for my.smscalls
     types-protobuf     # for my.google.maps.android


### PR DESCRIPTION
- switch to hatch for building package (should be no-op, it's somewhat nicer for editable packages though)
- remove hack for dependency groups introduced in https://github.com/karlicoss/HPI/commit/f492aa8849c01370837b4951fe31814009e0ba51

  latest pip supports `--group` syntax now, e.g. `pip install . --group testing`