### PR TITLE
general: sort out F401 (unused variable) warnings in ruff everywhere

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -3,7 +3,6 @@ import os
 import shutil
 import tempfile
 from contextlib import contextmanager
-from os.path import abspath
 from pathlib import Path
 from shutil import copytree, ignore_patterns
 from subprocess import DEVNULL, check_call
@@ -30,7 +29,7 @@ def run() -> None:
         check_call(f'{python} -m pip install        git+https://github.com/karlicoss/hypexport.git'.split())
     else:
         try:
-            import hypexport
+            import hypexport  # noqa: F401
         except ModuleNotFoundError:
             check_call(f'{python} -m pip --user git+https://github.com/karlicoss/hypexport.git'.split())
 

--- a/misc/check_legacy_init_py.py
+++ b/misc/check_legacy_init_py.py
@@ -4,7 +4,7 @@
 # config configured (can set it to '' though)
 
 from pathlib import Path
-from subprocess import PIPE, Popen, run
+from subprocess import PIPE, run
 from tempfile import TemporaryDirectory
 
 import logzero  # type: ignore[import]

--- a/ruff.toml
+++ b/ruff.toml
@@ -142,11 +142,14 @@ lint.ignore = [
     "RET503",  # TODO seems that ruff is ignoring noqa for this? double check and remove this line later
 
     "ARG001",  # ugh, kinda annoying when using pytest fixtures
-    "F401"  ,  # TODO nice to have, but annoying with NOT_HPI_MODULE thing
 ]
 
+lint.per-file-ignores."src/my/core/compat.py" = [
+    "F401",  # annoying, I think needs __all__ or something? not sure
+]
 
 lint.exclude = [
     "untracked/**",
     "doc/overlays/**",  # TODO clean up later?
+    "misc/repl.py",  # work in progress
 ]

--- a/src/my/books/kobo.py
+++ b/src/my/books/kobo.py
@@ -2,5 +2,5 @@ from my.core import warnings
 
 warnings.high('my.books.kobo is deprecated! Please use my.kobo instead!')
 
-from my.core.util import __NOT_HPI_MODULE__
+from my.core.util import __NOT_HPI_MODULE__  # noqa: F401
 from my.kobo import *

--- a/src/my/browser/common.py
+++ b/src/my/browser/common.py
@@ -1,4 +1,4 @@
-from my.core.util import __NOT_HPI_MODULE__
+from my.core.util import __NOT_HPI_MODULE__  # noqa: F401
 
 
 def _patch_browserexport_logs(level: int):

--- a/src/my/cfg.py
+++ b/src/my/cfg.py
@@ -1,7 +1,11 @@
-import my.config as config
-
-from .core import __NOT_HPI_MODULE__
-from .core import warnings as W
+from my.core import warnings
 
 # still used in Promnesia, maybe in dashboard?
-W.high("DEPRECATED! Please import my.config directly instead.")
+warnings.high("DEPRECATED! Import my.config directly instead.")
+
+from my.core import __NOT_HPI_MODULE__  # noqa: F401  # isort: skip
+
+from typing import TYPE_CHECKING
+
+if not TYPE_CHECKING:
+    import my.config as config  # noqa: F401

--- a/src/my/coding/commits.py
+++ b/src/my/coding/commits.py
@@ -72,7 +72,7 @@ class Commit:
     # for backwards compatibility, was misspelled previously
     @property
     def commited_dt(self) -> datetime:
-        high("DEPRECATED! Please replace 'commited_dt' with 'committed_dt' (two 't's instead of one)")
+        high("DEPRECATED! Replace 'commited_dt' with 'committed_dt' (two 't's instead of one)")
         return self.committed_dt
 
 

--- a/src/my/common.py
+++ b/src/my/common.py
@@ -1,6 +1,10 @@
-from .core.warnings import high
+from my.core import warnings
 
-high("DEPRECATED! Please use my.core.common instead.")
+warnings.high("DEPRECATED! Use my.core.common instead.")
 
-from .core import __NOT_HPI_MODULE__
-from .core.common import *
+from my.core import __NOT_HPI_MODULE__  # noqa: F401  # isort: skip
+
+from typing import TYPE_CHECKING
+
+if not TYPE_CHECKING:
+    from my.core.common import *

--- a/src/my/core/common.py
+++ b/src/my/core/common.py
@@ -236,7 +236,7 @@ if not TYPE_CHECKING:
     from .cachew import mcachew  # noqa: F401
 
     # this is kinda internal, should just use my.core.logging.setup_logger if necessary
-    from .logging import setup_logger
+    from .logging import setup_logger  # noqa: F401
     from .stats import Stats
     from .types import (
         Json,

--- a/src/my/core/compat.py
+++ b/src/my/core/compat.py
@@ -49,7 +49,7 @@ else:
 # bisect_left doesn't have a 'key' parameter (which we use)
 # till python3.10
 if sys.version_info[:2] <= (3, 9):
-    from typing import Any, Callable, List, Optional, TypeVar  # noqa: UP035
+    from typing import Any, Callable, TypeVar  # noqa: UP035
 
     X = TypeVar('X')
 

--- a/src/my/core/json.py
+++ b/src/my/core/json.py
@@ -39,7 +39,7 @@ def test_json_loads_orjson(data: str | bytes, description: str) -> None:
     import pytest
 
     try:
-        import orjson
+        import orjson  # noqa: F401
     except ModuleNotFoundError:
         pytest.fail("orjson is not installed")
 

--- a/src/my/core/tests/test_cachew.py
+++ b/src/my/core/tests/test_cachew.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from .common import skip_if_uses_optional_deps as pytestmark
+from .common import skip_if_uses_optional_deps as pytestmark  # noqa: F401
 
 # TODO ugh, this is very messy.. need to sort out config overriding here
 

--- a/src/my/error.py
+++ b/src/my/error.py
@@ -1,6 +1,11 @@
-from .core.warnings import high
+from my.core import warnings
 
-high("DEPRECATED! Please use my.core.error instead.")
+warnings.high("DEPRECATED! Use my.core.error instead.")
 
-from .core import __NOT_HPI_MODULE__
-from .core.error import *
+from my.core import __NOT_HPI_MODULE__  # noqa: F401  # isort: skip
+
+
+from typing import TYPE_CHECKING
+
+if not TYPE_CHECKING:
+    from my.core.error import *

--- a/src/my/fbmessenger/__init__.py
+++ b/src/my/fbmessenger/__init__.py
@@ -10,7 +10,7 @@ See https://github.com/karlicoss/HPI/blob/master/doc/MODULE_DESIGN.org#allpy for
 """
 
 # prevent it from appearing in modules list/doctor
-from ..core import __NOT_HPI_MODULE__
+from my.core import __NOT_HPI_MODULE__  # noqa: F401  # isort: skip
 
 # kinda annoying to keep it, but it's so legacy 'hpi module install my.fbmessenger' works
 # needs to be on the top level (since it's extracted via ast module)

--- a/src/my/fbmessenger/common.py
+++ b/src/my/fbmessenger/common.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from my.core import __NOT_HPI_MODULE__  # isort: skip
+from my.core import __NOT_HPI_MODULE__  # noqa: F401  # isort: skip
 
 from collections.abc import Iterator
 from typing import Protocol

--- a/src/my/fbmessenger/export.py
+++ b/src/my/fbmessenger/export.py
@@ -23,7 +23,7 @@ _new_section = getattr(user_config, 'fbmessengerexport', None)
 _old_attr    = getattr(user_config, 'export_db', None)
 
 if _new_section is None and _old_attr is not None:
-    high("""DEPRECATED! Please modify your fbmessenger config to look like:
+    high("""DEPRECATED! Modify your fbmessenger config to look like:
 
 class fbmessenger:
     class fbmessengerexport:

--- a/src/my/github/common.py
+++ b/src/my/github/common.py
@@ -4,7 +4,7 @@ Github events and their metadata: comments/issues/pull requests
 
 from __future__ import annotations
 
-from my.core import __NOT_HPI_MODULE__  # isort: skip
+from my.core import __NOT_HPI_MODULE__  # noqa: F401  # isort: skip
 
 
 from collections.abc import Iterable

--- a/src/my/google/maps/_android_protobuf.py
+++ b/src/my/google/maps/_android_protobuf.py
@@ -1,4 +1,4 @@
-from my.core import __NOT_HPI_MODULE__  # isort: skip
+from my.core import __NOT_HPI_MODULE__  # noqa: F401  # isort: skip
 
 # NOTE: this tool was quite useful https://github.com/aj3423/aproto
 

--- a/src/my/google/takeout/html.py
+++ b/src/my/google/takeout/html.py
@@ -4,7 +4,7 @@ Google Takeout exports: browsing history, search/youtube/google play activity
 
 from __future__ import annotations
 
-from my.core import __NOT_HPI_MODULE__  # isort: skip
+from my.core import __NOT_HPI_MODULE__  # noqa: F401  # isort: skip
 
 import re
 from collections.abc import Iterable

--- a/src/my/google/takeout/paths.py
+++ b/src/my/google/takeout/paths.py
@@ -4,7 +4,7 @@ Module for locating and accessing [[https://takeout.google.com][Google Takeout]]
 
 from __future__ import annotations
 
-from my.core import __NOT_HPI_MODULE__  # isort: skip
+from my.core import __NOT_HPI_MODULE__  # noqa: F401  # isort: skip
 
 from abc import abstractmethod
 from collections.abc import Iterable

--- a/src/my/ip/common.py
+++ b/src/my/ip/common.py
@@ -2,7 +2,7 @@
 Provides location/timezone data from IP addresses, using [[https://github.com/purarue/ipgeocache][ipgeocache]]
 """
 
-from my.core import __NOT_HPI_MODULE__  # isort: skip
+from my.core import __NOT_HPI_MODULE__  # noqa: F401  # isort: skip
 
 import ipaddress
 from collections.abc import Iterator

--- a/src/my/location/common.py
+++ b/src/my/location/common.py
@@ -1,4 +1,4 @@
-from my.core import __NOT_HPI_MODULE__  # isort: skip
+from my.core import __NOT_HPI_MODULE__  # noqa: F401  # isort: skip
 
 from collections.abc import Iterable, Iterator
 from dataclasses import dataclass

--- a/src/my/materialistic.py
+++ b/src/my/materialistic.py
@@ -1,5 +1,8 @@
-from .core.warnings import high
+from my.core import warnings
 
-high("DEPRECATED! Please use my.hackernews.materialistic instead.")
+warnings.high("DEPRECATED! Use my.hackernews.materialistic instead.")
 
-from .hackernews.materialistic import *
+from typing import TYPE_CHECKING
+
+if not TYPE_CHECKING:
+    from .hackernews.materialistic import *

--- a/src/my/media/movies.py
+++ b/src/my/media/movies.py
@@ -1,3 +1,12 @@
-from .imdb import get_movies
+from my.core import warnings
+
+warnings.high("DEPRECATED! Use my.media.imdb instead.")
+
+from my.core import __NOT_HPI_MODULE__  # noqa: F401  # isort: skip
+
+from typing import TYPE_CHECKING
+
+if not TYPE_CHECKING:
+    from .imdb import get_movies  # noqa: F401  # legacy import
 
 # TODO extract items from org mode? perhaps not very high priority

--- a/src/my/media/youtube.py
+++ b/src/my/media/youtube.py
@@ -1,10 +1,10 @@
-from my.core import __NOT_HPI_MODULE__  # isort: skip
+from my.core import warnings
+
+warnings.high("DEPRECATED! Use my.youtube.takeout instead.")
+
+from my.core import __NOT_HPI_MODULE__  # noqa: F401  # isort: skip
 
 from typing import TYPE_CHECKING
-
-from my.core.warnings import high
-
-high("DEPRECATED! Please use my.youtube.takeout instead.")
 
 if not TYPE_CHECKING:
     from my.youtube.takeout import *

--- a/src/my/photos/utils.py
+++ b/src/my/photos/utils.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from ..core import __NOT_HPI_MODULE__  # isort: skip
+from my.core import __NOT_HPI_MODULE__  # noqa: F401  # isort: skip
 
 from pathlib import Path
 

--- a/src/my/reddit/__init__.py
+++ b/src/my/reddit/__init__.py
@@ -10,7 +10,7 @@ See https://github.com/karlicoss/HPI/blob/master/doc/MODULE_DESIGN.org#allpy for
 """
 
 # prevent it from appearing in modules list/doctor
-from ..core import __NOT_HPI_MODULE__
+from my.core import __NOT_HPI_MODULE__  # noqa: F401
 
 # kinda annoying to keep it, but it's so legacy 'hpi module install my.reddit' works
 # needs to be on the top level (since it's extracted via ast module)

--- a/src/my/reddit/common.py
+++ b/src/my/reddit/common.py
@@ -3,7 +3,7 @@ This defines Protocol classes, which make sure that each different
 type of shared models have a standardized interface
 """
 
-from my.core import __NOT_HPI_MODULE__  # isort: skip
+from my.core import __NOT_HPI_MODULE__  # noqa: F401  # isort: skip
 
 from collections.abc import Iterator
 from itertools import chain

--- a/src/my/reddit/rexport.py
+++ b/src/my/reddit/rexport.py
@@ -48,7 +48,7 @@ def migration(attrs: Attrs) -> Attrs:
         attrs['export_path'] = ex.export_path
     else:
         warnings.high(
-            """DEPRECATED! Please modify your reddit config to look like:
+            """DEPRECATED! Modify your reddit config to look like:
 
 class reddit:
     class rexport:

--- a/src/my/rss/common.py
+++ b/src/my/rss/common.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from my.core import __NOT_HPI_MODULE__  # isort: skip
+from my.core import __NOT_HPI_MODULE__  # noqa: F401  # isort: skip
 
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, replace

--- a/src/my/tests/calendar.py
+++ b/src/my/tests/calendar.py
@@ -1,6 +1,6 @@
 from my.calendar.holidays import is_holiday
 
-from .shared_tz_config import config  # autoused fixture
+from .shared_tz_config import config  # noqa: F401  # autoused fixture
 
 
 def test_is_holiday() -> None:

--- a/src/my/tests/location/fallback.py
+++ b/src/my/tests/location/fallback.py
@@ -12,7 +12,7 @@ import my.ip.all as ip_module
 from my.ip.common import IP
 from my.location.fallback import via_ip
 
-from ..shared_tz_config import config  # autoused fixture
+from ..shared_tz_config import config  # noqa: F401  # autoused fixture
 
 
 # these are all tests for the bisect algorithm defined in via_ip.py

--- a/src/my/tests/tz.py
+++ b/src/my/tests/tz.py
@@ -9,7 +9,7 @@ import my.time.tz.via_location as tz_via_location
 from my.core import notnone
 from my.core.compat import fromisoformat
 
-from .shared_tz_config import config  # autoused fixture
+from .shared_tz_config import config  # noqa: F401  # autoused fixture
 
 
 def getzone(dt: datetime) -> str:

--- a/src/my/twitter/common.py
+++ b/src/my/twitter/common.py
@@ -1,4 +1,4 @@
-from my.core import __NOT_HPI_MODULE__  # isort: skip
+from my.core import __NOT_HPI_MODULE__  # noqa: F401  # isort: skip
 
 from collections.abc import Iterator
 from itertools import chain

--- a/src/my/util/hpi_heartbeat.py
+++ b/src/my/util/hpi_heartbeat.py
@@ -6,7 +6,7 @@ The idea of testing is that overlays extend this module, and add their own
 items to items(), and the checker asserts all overlays have contributed.
 """
 
-from my.core import __NOT_HPI_MODULE__  # isort: skip
+from my.core import __NOT_HPI_MODULE__  # noqa: F401 # isort: skip
 
 import sys
 from collections.abc import Iterator

--- a/tests_misc/emfit.py
+++ b/tests_misc/emfit.py
@@ -1,4 +1,4 @@
-from my.tests.common import skip_if_not_karlicoss as pytestmark
+from my.tests.common import skip_if_not_karlicoss as pytestmark  # noqa: F401  # isort: skip
 
 
 def test() -> None:

--- a/tests_misc/extra/polar.py
+++ b/tests_misc/extra/polar.py
@@ -1,4 +1,3 @@
-import sys
 from importlib import reload
 from pathlib import Path
 
@@ -16,7 +15,7 @@ def test_hpi(prepare: str) -> None:
     assert len(list(get_entries())) > 1
 
 def test_orger(prepare: str, tmp_path: Path) -> None:
-    from my.core.utils.imports import import_file, import_from
+    from my.core.utils.imports import import_file
     om = import_file(ROOT / 'orger/modules/polar.py')
     # reload(om)
 

--- a/tests_misc/foursquare.py
+++ b/tests_misc/foursquare.py
@@ -1,4 +1,4 @@
-from my.tests.common import skip_if_not_karlicoss as pytestmark  # isort: skip
+from my.tests.common import skip_if_not_karlicoss as pytestmark  # noqa: F401  # isort: skip
 
 
 def test_checkins() -> None:

--- a/tests_misc/github.py
+++ b/tests_misc/github.py
@@ -1,4 +1,4 @@
-from my.tests.common import skip_if_not_karlicoss as pytestmark  # isort: skip
+from my.tests.common import skip_if_not_karlicoss as pytestmark  # noqa: F401  # isort: skip
 
 from more_itertools import ilen
 

--- a/tests_misc/goodreads.py
+++ b/tests_misc/goodreads.py
@@ -1,4 +1,4 @@
-from my.tests.common import skip_if_not_karlicoss as pytestmark  # isort: skip
+from my.tests.common import skip_if_not_karlicoss as pytestmark  # noqa: F401  # isort: skip
 
 from more_itertools import ilen
 

--- a/tests_misc/hypothesis.py
+++ b/tests_misc/hypothesis.py
@@ -1,4 +1,4 @@
-from my.tests.common import skip_if_not_karlicoss as pytestmark  # isort: skip
+from my.tests.common import skip_if_not_karlicoss as pytestmark  # noqa: F401  # isort: skip
 
 
 def test() -> None:

--- a/tests_misc/instapaper.py
+++ b/tests_misc/instapaper.py
@@ -1,4 +1,4 @@
-from my.tests.common import skip_if_not_karlicoss as pytestmark  # isort: skip
+from my.tests.common import skip_if_not_karlicoss as pytestmark  # noqa: F401  # isort: skip
 
 
 def test_pages() -> None:

--- a/tests_misc/jawbone.py
+++ b/tests_misc/jawbone.py
@@ -1,4 +1,4 @@
-from my.tests.common import skip_if_not_karlicoss as pytestmark # isort: skip
+from my.tests.common import skip_if_not_karlicoss as pytestmark  # noqa: F401  # isort: skip
 
 from datetime import date, time
 

--- a/tests_misc/lastfm.py
+++ b/tests_misc/lastfm.py
@@ -1,4 +1,4 @@
-from my.tests.common import skip_if_not_karlicoss as pytestmark  # isort: skip
+from my.tests.common import skip_if_not_karlicoss as pytestmark  # noqa: F401  # isort: skip
 
 
 # todo maybe belongs to common

--- a/tests_misc/orgmode.py
+++ b/tests_misc/orgmode.py
@@ -1,9 +1,10 @@
-from my.tests.common import skip_if_not_karlicoss as pytestmark  # isort: skip
+from my.tests.common import skip_if_not_karlicoss as pytestmark  # noqa: F401  # isort: skip
 
 
 def test() -> None:
     from my import orgmode
-    from my.core.orgmode import collect
+    # FIXME why it's not used? Did I intend to test?
+    # from my.core.orgmode import collect  # noqa: F401
 
     # meh
     results = list(orgmode.query().collect_all(lambda n: [n] if 'python' in n.tags else []))

--- a/tests_misc/rtm.py
+++ b/tests_misc/rtm.py
@@ -1,4 +1,4 @@
-from my.tests.common import skip_if_not_karlicoss as pytestmark  # isort: skip
+from my.tests.common import skip_if_not_karlicoss as pytestmark  # noqa: F401  # isort: skip
 
 
 def test() -> None:

--- a/tests_misc/smscalls.py
+++ b/tests_misc/smscalls.py
@@ -1,4 +1,4 @@
-from my.tests.common import skip_if_not_karlicoss as pytestmark  # isort: skip
+from my.tests.common import skip_if_not_karlicoss as pytestmark  # noqa: F401  # isort: skip
 
 # TODO maybe instead detect if it has any data at all
 # if none, then skip the test, say that user doesn't have any data?

--- a/tests_misc/takeout.py
+++ b/tests_misc/takeout.py
@@ -1,4 +1,4 @@
-from my.tests.common import skip_if_not_karlicoss as pytestmark  # isort: skip
+from my.tests.common import skip_if_not_karlicoss as pytestmark  # noqa: F401  # isort: skip
 
 from datetime import datetime, timezone
 from itertools import islice
@@ -60,9 +60,8 @@ def parse_takeout_xmllint(data: str):
     # the only downside is that html.parser isn't iterative.. might be able to hack with some iternal hacks?
     # wonder what's the bottleneck..
     #
-    from subprocess import PIPE, Popen, run
+    from subprocess import PIPE, run
 
-    from more_itertools import split_before
     res = run(
         ['xmllint', '--html', '--xpath', '//div[contains(@class, "content-cell")]', '-'],
         input=data.encode('utf8'),
@@ -73,4 +72,4 @@ def parse_takeout_xmllint(data: str):
     # out = data
     return out.split('<div class="content-cell')
 
-from my.google.takeout.html import test_parse_dt
+from my.google.takeout.html import test_parse_dt  # noqa: F401

--- a/tests_misc/tweets.py
+++ b/tests_misc/tweets.py
@@ -1,4 +1,4 @@
-from my.tests.common import skip_if_not_karlicoss as pytestmark  # isort: skip
+from my.tests.common import skip_if_not_karlicoss as pytestmark  # noqa: F401  # isort: skip
 # todo current test doesn't depend on data, in principle...
 # should make lazy loading the default..
 

--- a/tests_misc/youtube.py
+++ b/tests_misc/youtube.py
@@ -1,4 +1,4 @@
-from my.tests.common import skip_if_not_karlicoss as pytestmark  # isort: skip
+from my.tests.common import skip_if_not_karlicoss as pytestmark  # noqa: F401  # isort: skip
 
 # TODO move elsewhere?
 # these tests would only make sense with some existing data? although some of them would work for everyone..


### PR DESCRIPTION
- use them explicitly on pytestmark -- there aren't that many anyway
- use them explicitly on __NOT_HPI_MODULE__ -- there aren't that many anyway

also some general cleanup for 'legacy' submodules, e.g. hide imports under TYPE_CHECKING