### PR TITLE
general: use full dependency specifiers (i.e. "package-name @ git+htps://..." in REQUIRES)

### DIFF
--- a/src/my/emfit/__init__.py
+++ b/src/my/emfit/__init__.py
@@ -7,7 +7,7 @@ Consumes data exported by https://github.com/karlicoss/emfitexport
 from __future__ import annotations
 
 REQUIRES = [
-    'git+https://github.com/karlicoss/emfitexport',
+    'emfitexport @ git+https://github.com/karlicoss/emfitexport',
 ]
 
 import dataclasses

--- a/src/my/endomondo.py
+++ b/src/my/endomondo.py
@@ -3,9 +3,8 @@ Endomondo exercise data
 '''
 
 REQUIRES = [
-    'git+https://github.com/karlicoss/endoexport',
+    'endoexport[dal] @ git+https://github.com/karlicoss/endoexport',
 ]
-# todo use ast in setup.py or doctor to extract the corresponding pip packages?
 
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass

--- a/src/my/fbmessenger/__init__.py
+++ b/src/my/fbmessenger/__init__.py
@@ -15,7 +15,7 @@ from my.core import __NOT_HPI_MODULE__  # noqa: F401  # isort: skip
 # kinda annoying to keep it, but it's so legacy 'hpi module install my.fbmessenger' works
 # needs to be on the top level (since it's extracted via ast module)
 REQUIRES = [
-    'git+https://github.com/karlicoss/fbmessengerexport',
+    'fbmessengerexport @ git+https://github.com/karlicoss/fbmessengerexport',
 ]
 
 

--- a/src/my/fbmessenger/export.py
+++ b/src/my/fbmessenger/export.py
@@ -4,7 +4,7 @@ Facebook Messenger messages
 Uses the output of [[https://github.com/karlicoss/fbmessengerexport][fbmessengerexport]]
 """
 REQUIRES = [
-    'git+https://github.com/karlicoss/fbmessengerexport',
+    'fbmessengerexport @ git+https://github.com/karlicoss/fbmessengerexport',
 ]
 
 from collections.abc import Iterator

--- a/src/my/github/ghexport.py
+++ b/src/my/github/ghexport.py
@@ -5,7 +5,7 @@ Github data: events, comments, etc. (API data)
 from __future__ import annotations
 
 REQUIRES = [
-    'git+https://github.com/karlicoss/ghexport',
+    'ghexport @ git+https://github.com/karlicoss/ghexport',
 ]
 
 from dataclasses import dataclass

--- a/src/my/goodreads.py
+++ b/src/my/goodreads.py
@@ -2,7 +2,7 @@
 [[https://www.goodreads.com][Goodreads]] statistics
 """
 REQUIRES = [
-    'git+https://github.com/karlicoss/goodrexport',
+    'goodrexport @ git+https://github.com/karlicoss/goodrexport',
 ]
 
 

--- a/src/my/google/takeout/parser.py
+++ b/src/my/google/takeout/parser.py
@@ -12,7 +12,9 @@ zip files of the exports, which are temporarily unpacked while creating
 the cachew cache
 """
 
-REQUIRES = ["git+https://github.com/purarue/google_takeout_parser"]
+REQUIRES = [
+    "google-takeout-parser @ git+https://github.com/purarue/google_takeout_parser"
+]
 
 import os
 from collections.abc import Sequence

--- a/src/my/hypothesis.py
+++ b/src/my/hypothesis.py
@@ -2,7 +2,7 @@
 [[https://hypothes.is][Hypothes.is]] highlights and annotations
 """
 REQUIRES = [
-    'git+https://github.com/karlicoss/hypexport',
+    'hypexport @ git+https://github.com/karlicoss/hypexport',
 ]
 from collections.abc import Iterator, Sequence
 from dataclasses import dataclass

--- a/src/my/instapaper.py
+++ b/src/my/instapaper.py
@@ -2,7 +2,7 @@
 [[https://www.instapaper.com][Instapaper]] bookmarks, highlights and annotations
 """
 REQUIRES = [
-    'git+https://github.com/karlicoss/instapexport',
+    'instapexport @ git+https://github.com/karlicoss/instapexport',
 ]
 
 from dataclasses import dataclass

--- a/src/my/ip/all.py
+++ b/src/my/ip/all.py
@@ -6,7 +6,9 @@ To use this, you'd add IP providers that yield IPs to the 'ips' function
 For an example of how this could be used, see https://github.com/purarue/HPI/tree/master/my/ip
 """
 
-REQUIRES = ["git+https://github.com/purarue/ipgeocache"]
+REQUIRES = [
+    "ipgeocache @ git+https://github.com/purarue/ipgeocache"
+]
 
 
 from collections.abc import Iterator

--- a/src/my/location/fallback/via_ip.py
+++ b/src/my/location/fallback/via_ip.py
@@ -2,7 +2,10 @@
 Converts IP addresses provided by my.location.ip to estimated locations
 """
 
-REQUIRES = ["git+https://github.com/purarue/ipgeocache"]
+REQUIRES = [
+    "ipgeocache @ git+https://github.com/purarue/ipgeocache"
+]
+
 
 from dataclasses import dataclass
 from datetime import timedelta

--- a/src/my/location/google_takeout.py
+++ b/src/my/location/google_takeout.py
@@ -2,7 +2,9 @@
 Extracts locations using google_takeout_parser -- no shared code with the deprecated my.location.google
 """
 
-REQUIRES = ["git+https://github.com/purarue/google_takeout_parser"]
+REQUIRES = [
+    "google-takeout-parser @ git+https://github.com/purarue/google_takeout_parser"
+]
 
 from collections.abc import Iterator
 

--- a/src/my/location/google_takeout_semantic.py
+++ b/src/my/location/google_takeout_semantic.py
@@ -5,7 +5,9 @@ Extracts semantic location history using google_takeout_parser
 # This is a separate module to prevent ImportError and a new config block from breaking
 # previously functional my.location.google_takeout locations
 
-REQUIRES = ["git+https://github.com/purarue/google_takeout_parser"]
+REQUIRES = [
+    "google-takeout-parser @ git+https://github.com/purarue/google_takeout_parser"
+]
 
 from collections.abc import Iterator
 from dataclasses import dataclass

--- a/src/my/location/via_ip.py
+++ b/src/my/location/via_ip.py
@@ -1,4 +1,6 @@
-REQUIRES = ["git+https://github.com/purarue/ipgeocache"]
+REQUIRES = [
+    "ipgeocache @ git+https://github.com/purarue/ipgeocache"
+]
 
 from my.core.warnings import high
 

--- a/src/my/monzo/monzoexport.py
+++ b/src/my/monzo/monzoexport.py
@@ -2,7 +2,7 @@
 Monzo transactions data (using https://github.com/karlicoss/monzoexport )
 """
 REQUIRES = [
-    'git+https://github.com/karlicoss/monzoexport',
+    'monzoexport @ git+https://github.com/karlicoss/monzoexport',
 ]
 
 from collections.abc import Iterator, Sequence

--- a/src/my/pdfs.py
+++ b/src/my/pdfs.py
@@ -4,8 +4,7 @@ PDF documents and annotations on your filesystem
 from __future__ import annotations as _annotations
 
 REQUIRES = [
-    'git+https://github.com/0xabu/pdfannots',
-    # todo not sure if should use pypi version?
+    'pdfannots',
 ]
 
 import time

--- a/src/my/pinboard.py
+++ b/src/my/pinboard.py
@@ -2,7 +2,7 @@
 [[https://pinboard.in][Pinboard]] bookmarks
 """
 REQUIRES = [
-    'git+https://github.com/karlicoss/pinbexport',
+    'pinbexport @ git+https://github.com/karlicoss/pinbexport',
 ]
 
 from collections.abc import Iterator, Sequence

--- a/src/my/pocket.py
+++ b/src/my/pocket.py
@@ -2,7 +2,7 @@
 [[https://getpocket.com][Pocket]] bookmarks and highlights
 """
 REQUIRES = [
-    'git+https://github.com/karlicoss/pockexport',
+    'pockexport @ git+https://github.com/karlicoss/pockexport',
 ]
 from dataclasses import dataclass
 from typing import TYPE_CHECKING

--- a/src/my/reddit/__init__.py
+++ b/src/my/reddit/__init__.py
@@ -15,7 +15,7 @@ from my.core import __NOT_HPI_MODULE__  # noqa: F401
 # kinda annoying to keep it, but it's so legacy 'hpi module install my.reddit' works
 # needs to be on the top level (since it's extracted via ast module)
 REQUIRES = [
-    'git+https://github.com/karlicoss/rexport',
+    'rexport @ git+https://github.com/karlicoss/rexport',
 ]
 
 

--- a/src/my/reddit/pushshift.py
+++ b/src/my/reddit/pushshift.py
@@ -5,7 +5,7 @@ See https://github.com/purarue/pushshift_comment_export
 """
 
 REQUIRES = [
-    "git+https://github.com/purarue/pushshift_comment_export",
+    "pushshift-comment-export @ git+https://github.com/purarue/pushshift_comment_export",
 ]
 
 from dataclasses import dataclass

--- a/src/my/reddit/rexport.py
+++ b/src/my/reddit/rexport.py
@@ -4,7 +4,7 @@ Reddit data: saved items/comments/upvotes/etc.
 from __future__ import annotations
 
 REQUIRES = [
-    'git+https://github.com/karlicoss/rexport',
+    'rexport @ git+https://github.com/karlicoss/rexport',
 ]
 
 import inspect

--- a/src/my/rescuetime.py
+++ b/src/my/rescuetime.py
@@ -2,7 +2,7 @@
 Rescuetime (phone activity tracking) data.
 '''
 REQUIRES = [
-    'git+https://github.com/karlicoss/rescuexport',
+    'rescuexport @ git+https://github.com/karlicoss/rescuexport',
 ]
 
 from collections.abc import Iterable, Sequence

--- a/src/my/stackexchange/stexport.py
+++ b/src/my/stackexchange/stexport.py
@@ -2,7 +2,7 @@
 Stackexchange data (uses API via [[https://github.com/karlicoss/stexport][stexport]])
 '''
 REQUIRES = [
-    'git+https://github.com/karlicoss/stexport',
+    'stexport @ git+https://github.com/karlicoss/stexport',
 ]
 
 from dataclasses import dataclass


### PR DESCRIPTION
I.e. according to https://packaging.python.org/en/latest/specifications/dependency-specifiers/#dependency-specifiers

This is a bit nicer since
- more explicit, allows to tell the package name straighaway, including automatic tooling
- allows to specity extras (e.g. endoexport[dal] in this MR is an example)

Should not make any difference for `hpi module install` otherwise