### PR TITLE
general: set min version to 3.12; update ci to run 3.14

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,15 +30,13 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14-dev']
+        python-version: ['3.12', '3.13', '3.14']
         exclude: [
             # windows runners are pretty scarce, so let's only run lowest and highest python version
-            {platform: windows-latest, python-version: '3.11'},
-            {platform: windows-latest, python-version: '3.12'},
+            {platform: windows-latest, python-version: '3.13'},
 
             # same, macos is a bit too slow and ubuntu covers python quirks well
-            {platform: macos-latest  , python-version: '3.11' },
-            {platform: macos-latest  , python-version: '3.12' },
+            {platform: macos-latest  , python-version: '3.13' },
         ]
 
     runs-on: ${{ matrix.platform }}
@@ -50,16 +48,16 @@ jobs:
     # ugh https://github.com/actions/toolkit/blob/main/docs/commands.md#path-manipulation
     - run: echo "$HOME/.local/bin" >> $GITHUB_PATH
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         submodules: recursive
         fetch-depth: 0  # nicer to have all git history when debugging/for tests
 
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
       
-    - uses: astral-sh/setup-uv@v5
+    - uses: astral-sh/setup-uv@v7
       with:
         enable-cache: false  # we don't have lock files, so can't use them as cache key
 
@@ -100,16 +98,16 @@ jobs:
     # ugh https://github.com/actions/toolkit/blob/main/docs/commands.md#path-manipulation
     - run: echo "$HOME/.local/bin" >> $GITHUB_PATH
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         submodules: recursive
         fetch-depth: 0  # pull all commits to correctly infer vcs version
 
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v6
       with:
         python-version: '3.12'
 
-    - uses: astral-sh/setup-uv@v5
+    - uses: astral-sh/setup-uv@v7
       with:
         enable-cache: false  # we don't have lock files, so can't use them as cache key
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "kompress>=0.2.20240918" , # for transparent access to compressed files via pathlib.Path
 
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 
 ## these need to be set if you're planning to upload to pypi
 description = "A Python interface to my life"
@@ -65,7 +65,7 @@ typecheck = [
     { include-group = "testing" },
     "mypy",
     "lxml",  # for mypy coverage
-    "ty>=0.0.1a21",
+    "ty>=0.0.1a22",
 
     "HPI[optional]",
     "orgparse",  # for my.core.orgmode

--- a/ruff.toml
+++ b/ruff.toml
@@ -98,6 +98,10 @@ lint.ignore = [
     "PLC0415", # "imports should be at the top level" -- not realistic
 
     "ARG001",  # ugh, kinda annoying when using pytest fixtures
+
+    # FIXME hmm. Need to figure out if cachew works fine with type = defined types before updating things..
+    "UP047",   # non-pep695-generic-function
+    "UP040",   # non-pep695-type-alias
 ]
 
 lint.per-file-ignores."src/my/core/compat.py" = [

--- a/src/my/arbtt.py
+++ b/src/my/arbtt.py
@@ -10,13 +10,13 @@ REQUIRES = ['ijson', 'cffi']
 
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
+from datetime import datetime
 from pathlib import Path
 from subprocess import PIPE, Popen
 
 import ijson  # type: ignore[import-untyped]
 
 from my.core import Json, PathIsh, Stats, datetime_aware, get_files, stat
-from my.core.compat import fromisoformat
 
 
 def inputs() -> Sequence[Path]:
@@ -46,7 +46,6 @@ class Entry:
     @property
     def dt(self) -> datetime_aware:
         # contains utc already
-        # TODO after python>=3.11, could just use fromisoformat
         ds = self.json['date']
         elen = 27
         lds = len(ds)
@@ -57,7 +56,7 @@ class Entry:
             # and sometimes more...
             ds = ds[: elen - 1] + 'Z'
 
-        return fromisoformat(ds)
+        return datetime.fromisoformat(ds)
 
     @property
     def active(self) -> str | None:

--- a/src/my/bumble/android.py
+++ b/src/my/bumble/android.py
@@ -11,12 +11,11 @@ from collections.abc import Iterator, Sequence
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import Protocol
+from typing import Protocol, assert_never
 
 from more_itertools import unique_everseen
 
 from my.core import Paths, Res, get_files
-from my.core.compat import assert_never
 from my.core.sqlite import select, sqlite_connection
 
 

--- a/src/my/codeforces.py
+++ b/src/my/codeforces.py
@@ -1,7 +1,7 @@
 import json
 from collections.abc import Iterator, Sequence
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from functools import cached_property
 from pathlib import Path
 
@@ -45,7 +45,7 @@ class Parser:
         for c in j['result']:
             yield Contest(
                 contest_id=c['id'],
-                when=datetime.fromtimestamp(c['startTimeSeconds'], tz=timezone.utc),
+                when=datetime.fromtimestamp(c['startTimeSeconds'], tz=UTC),
                 name=c['name'],
             )
 

--- a/src/my/core/common.py
+++ b/src/my/core/common.py
@@ -5,11 +5,7 @@ import traceback
 from collections.abc import Callable, Iterable, Sequence
 from glob import glob as do_glob
 from pathlib import Path
-from typing import (
-    TYPE_CHECKING,
-    Generic,
-    TypeVar,
-)
+from typing import TYPE_CHECKING
 
 from . import compat, warnings
 
@@ -106,22 +102,19 @@ def get_files(
     return tuple(paths)
 
 
-_R = TypeVar('_R')
-
-
 # https://stackoverflow.com/a/5192374/706389
 # NOTE: it was added to stdlib in 3.9 and then deprecated in 3.11
 # seems that the suggested solution is to use custom decorator?
-class classproperty(Generic[_R]):
-    def __init__(self, f: Callable[..., _R]) -> None:
+class classproperty[R]:
+    def __init__(self, f: Callable[..., R]) -> None:
         self.f = f
 
-    def __get__(self, obj, cls) -> _R:
+    def __get__(self, obj, cls) -> R:
         return self.f(cls)
 
 
 def test_classproperty() -> None:
-    from .compat import assert_type
+    from typing import assert_type
 
     class C:
         @classproperty
@@ -129,7 +122,7 @@ def test_classproperty() -> None:
             return 'hello'
 
     res = C.prop
-    assert_type(res, str)
+    assert_type(res, str)  # ty: ignore[type-assertion-failure]
     assert res == 'hello'
 
 
@@ -247,7 +240,7 @@ if not TYPE_CHECKING:
 
     tzdatetime = datetime_aware
 else:
-    from .compat import Never
+    from typing import Never
 
     # make these invalid during type check while working in runtime
     Stats = Never

--- a/src/my/core/compat.py
+++ b/src/my/core/compat.py
@@ -32,91 +32,25 @@ if not TYPE_CHECKING:
     def removesuffix(text: str, suffix: str) -> str:
         return text.removesuffix(suffix)
 
-    ##
-
     ## used to have compat function before 3.8 for these, keeping for runtime back compatibility
     from bisect import bisect_left
     from functools import cached_property
     from types import NoneType
 
-    # used to have compat function before 3.9 for these, keeping for runtime back compatibility
+    ##
+    ## used to have compat function before 3.9 for these, keeping for runtime back compatibility
     from typing import Literal, ParamSpec, Protocol, TypeAlias, TypedDict
 
     _KwOnlyType = TypedDict("_KwOnlyType", {"kw_only": Literal[True]})  # noqa: UP013
     KW_ONLY: _KwOnlyType = {"kw_only": True}
-##
+    ##
 
+    ## old compat for python <3.12
+    from datetime import datetime
 
-from datetime import datetime
-
-if sys.version_info[:2] >= (3, 11):
     fromisoformat = datetime.fromisoformat
-else:
-    # fromisoformat didn't support Z as "utc" before 3.11
-    # https://docs.python.org/3/library/datetime.html#datetime.datetime.fromisoformat
 
-    def fromisoformat(date_string: str) -> datetime:
-        if date_string.endswith('Z'):
-            date_string = date_string[:-1] + '+00:00'
-        return datetime.fromisoformat(date_string)
-
-
-def test_fromisoformat() -> None:
-    from datetime import timezone
-
-    # fmt: off
-    # feedbin has this format
-    assert fromisoformat('2020-05-01T10:32:02.925961Z') == datetime(
-        2020, 5, 1, 10, 32, 2, 925961, timezone.utc,
-    )
-
-    # polar has this format
-    assert fromisoformat('2018-11-28T22:04:01.304Z') == datetime(
-        2018, 11, 28, 22, 4, 1, 304000, timezone.utc,
-    )
-
-    # stackexchange, runnerup has this format
-    assert fromisoformat('2020-11-30T00:53:12Z') == datetime(
-        2020, 11, 30, 0, 53, 12, 0, timezone.utc,
-    )
-    # fmt: on
-
-    # arbtt has this format (sometimes less/more than 6 digits in milliseconds)
-    # TODO doesn't work atm, not sure if really should be supported...
-    # maybe should have flags for weird formats?
-    # assert isoparse('2017-07-18T18:59:38.21731Z') == datetime(
-    #     2017, 7, 18, 18, 59, 38, 217310, timezone.utc,
-    # )
-
-
-if sys.version_info[:2] >= (3, 11):
     from typing import Never, assert_never, assert_type
-else:
-    from typing_extensions import Never, assert_never, assert_type
 
-
-if sys.version_info[:2] >= (3, 11):
     add_note = BaseException.add_note
-else:
-
-    def add_note(e: BaseException, note: str) -> None:
-        """
-        Backport of BaseException.add_note
-        """
-
-        # The only (somewhat annoying) difference is it will log extra lines for notes past the main exception message:
-        # (i.e. line 2 here:)
-
-        # 1 [ERROR   2025-02-04 22:12:21] Main exception message
-        # 2 ^ extra note
-        # 3 Traceback (most recent call last):
-        # 4   File "run.py", line 19, in <module>
-        # 5     ee = test()
-        # 6   File "run.py", line 5, in test
-        # 7     raise RuntimeError("Main exception message")
-        # 8 RuntimeError: Main exception message
-        # 9 ^ extra note
-
-        args = e.args
-        if len(args) == 1 and isinstance(args[0], str):
-            e.args = (e.args[0] + '\n' + note,)
+    ##

--- a/src/my/core/freezer.py
+++ b/src/my/core/freezer.py
@@ -2,13 +2,11 @@ from __future__ import annotations
 
 import dataclasses
 import inspect
-from typing import Any, Generic, TypeVar
-
-D = TypeVar('D')
+from typing import Any
 
 
-def _freeze_dataclass(Orig: type[D]):
-    ofields = [(f.name, f.type, f) for f in dataclasses.fields(Orig)]  # type: ignore[arg-type]  # see https://github.com/python/typing_extensions/issues/115
+def _freeze_dataclass(Orig: type):
+    ofields = [(f.name, f.type, f) for f in dataclasses.fields(Orig)]
 
     # extract properties along with their types
     props = list(inspect.getmembers(Orig, lambda o: isinstance(o, property)))
@@ -20,7 +18,7 @@ def _freeze_dataclass(Orig: type[D]):
     return props, RRR
 
 
-class Freezer(Generic[D]):
+class Freezer[D]:
     '''
     Some magic which converts dataclass properties into fields.
     It could be useful for better serialization, for performance, for using type as a schema.

--- a/src/my/core/query_range.py
+++ b/src/my/core/query_range.py
@@ -18,7 +18,6 @@ from typing import Any, NamedTuple
 
 import more_itertools
 
-from .compat import fromisoformat
 from .query import (
     ET,
     OrderFunc,
@@ -79,10 +78,6 @@ def parse_datetime_float(date_str: str) -> float:
         # this also parses dates like '2020-01-01'
         return datetime.fromisoformat(ds).timestamp()
     except ValueError:
-        pass
-    try:
-        return fromisoformat(ds).timestamp()
-    except (AssertionError, ValueError):
         pass
 
     try:

--- a/src/my/core/sqlite.py
+++ b/src/my/core/sqlite.py
@@ -6,11 +6,10 @@ from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Any, Literal, overload
+from typing import Any, Literal, assert_never, overload
 
 from . import warnings
 from .common import PathIsh
-from .compat import assert_never
 
 
 def sqlite_connect_immutable(db: PathIsh) -> sqlite3.Connection:
@@ -67,7 +66,7 @@ def sqlite_connection(
         elif row_factory == 'dict':
             row_factory_ = dict_factory
         else:
-            assert_never(row_factory)
+            assert_never(row_factory)  # ty: ignore[type-assertion-failure]  # I think ty is confused about callable()
 
 
     if _via_apsw:

--- a/src/my/core/stats.py
+++ b/src/my/core/stats.py
@@ -404,10 +404,10 @@ def _stat_iterable(it: Iterable[Any], *, quick: bool = False) -> Stats:
 
 
 def test_stat_iterable() -> None:
-    from datetime import datetime, timedelta, timezone
+    from datetime import UTC, datetime, timedelta
     from typing import NamedTuple
 
-    dd = datetime.fromtimestamp(123, tz=timezone.utc)
+    dd = datetime.fromtimestamp(123, tz=UTC)
     day = timedelta(days=3)
 
     class X(NamedTuple):
@@ -444,11 +444,10 @@ def _guess_datetime(x: Any) -> datetime | None:
 
 def test_guess_datetime() -> None:
     from dataclasses import dataclass
+    from datetime import datetime
     from typing import NamedTuple
 
-    from .compat import fromisoformat
-
-    dd = fromisoformat('2021-02-01T12:34:56Z')
+    dd = datetime.fromisoformat('2021-02-01T12:34:56Z')
 
     class A(NamedTuple):
         x: int

--- a/src/my/core/utils/itertools.py
+++ b/src/my/core/utils/itertools.py
@@ -115,7 +115,7 @@ else:
 
 
 def test_listify() -> None:
-    from ..compat import assert_type
+    from typing import assert_type
 
     @listify
     def it() -> Iterator[int]:
@@ -123,7 +123,7 @@ def test_listify() -> None:
         yield 2
 
     res = it()
-    assert_type(res, list[int])
+    assert_type(res, list[int])  # ty: ignore[type-assertion-failure]
     assert res == [1, 2]
 
 
@@ -162,7 +162,7 @@ else:
 
 
 def test_warn_if_empty_iterator() -> None:
-    from ..compat import assert_type
+    from typing import assert_type
 
     @warn_if_empty
     def nonempty() -> Iterator[str]:
@@ -189,7 +189,7 @@ def test_warn_if_empty_iterator() -> None:
 
 
 def test_warn_if_empty_list() -> None:
-    from ..compat import assert_type
+    from typing import assert_type
 
     ll = [1, 2, 3]
 
@@ -261,10 +261,9 @@ def check_if_hashable(iterable: Iterable[_HT]) -> Iterable[_HT]:
 # TODO different policies -- error/warn/ignore?
 def test_check_if_hashable() -> None:
     from dataclasses import dataclass
+    from typing import assert_type
 
     import pytest
-
-    from ..compat import assert_type
 
     x1: list[int] = [1, 2]
     r1 = check_if_hashable(x1)
@@ -273,12 +272,12 @@ def test_check_if_hashable() -> None:
 
     x2: Iterator[int | str] = iter((123, 'aba'))
     r2 = check_if_hashable(x2)
-    assert_type(r2, Iterable[int | str])
+    assert_type(r2, Iterable[int | str])  # ty: ignore[type-assertion-failure]  # atm ty is a bit confused about generics
     assert list(r2) == [123, 'aba']
 
     x3: tuple[object, ...] = (789, 'aba')
     r3 = check_if_hashable(x3)
-    assert_type(r3, Iterable[object])
+    assert_type(r3, Iterable[object])  # ty: ignore[type-assertion-failure]  # ty thinks it's Literal[789, 'aba']? odd
     assert r3 is x3  # object should be unchanged
 
     x4: list[set[int]] = [{1, 2, 3}, {4, 5, 6}]

--- a/src/my/demo.py
+++ b/src/my/demo.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import json
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
-from datetime import datetime, timezone, tzinfo
+from datetime import UTC, datetime, tzinfo
 from pathlib import Path
 from typing import Protocol
 
@@ -20,7 +20,7 @@ class config(Protocol):
     username: str
 
     # this is to check optional attribute handling
-    timezone: tzinfo = timezone.utc
+    timezone: tzinfo = UTC
 
     external: PathIsh | None = None
 

--- a/src/my/experimental/destructive_parsing.py
+++ b/src/my/experimental/destructive_parsing.py
@@ -1,9 +1,7 @@
 from collections.abc import Iterator
 from dataclasses import dataclass
 from types import NoneType
-from typing import Any
-
-from my.core.compat import assert_never
+from typing import Any, assert_never
 
 
 # TODO Popper? not sure
@@ -31,7 +29,7 @@ class Helper:
         return self.manager.helper(item=self.item.pop(key), path=(*self.path, key))
 
 
-def is_empty(x) -> bool:  # noqa: RET503
+def is_empty(x) -> bool:
     if isinstance(x, dict):
         return len(x) == 0
     elif isinstance(x, list):

--- a/src/my/github/common.py
+++ b/src/my/github/common.py
@@ -8,7 +8,7 @@ from my.core import __NOT_HPI_MODULE__  # noqa: F401  # isort: skip
 
 
 from collections.abc import Iterable
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import NamedTuple
 
 from my.core import datetime_aware, make_logger, warn_if_empty
@@ -49,7 +49,7 @@ def merge_events(*sources: Results) -> Results:
 
 def parse_dt(s: str) -> datetime_aware:
     # TODO isoformat?
-    return datetime.strptime(s, '%Y-%m-%dT%H:%M:%SZ').replace(tzinfo=timezone.utc)
+    return datetime.strptime(s, '%Y-%m-%dT%H:%M:%SZ').replace(tzinfo=UTC)
 
 
 # experimental way of supportint event ids... not sure

--- a/src/my/github/gdpr.py
+++ b/src/my/github/gdpr.py
@@ -19,7 +19,6 @@ from my.core import (
     stat,
     warnings,
 )
-from my.core.compat import add_note
 from my.core.json import json_loads
 
 from .common import Event, EventIds, parse_dt
@@ -136,7 +135,7 @@ def _process_one(root: Path) -> Iterator[Res[Event]]:
             try:
                 yield handler(r)
             except Exception as e:
-                add_note(e, f'^ while processing {f}')
+                e.add_note(f'^ while processing {f}')
                 yield e
 
 

--- a/src/my/google/maps/android.py
+++ b/src/my/google/maps/android.py
@@ -9,7 +9,7 @@ REQUIRES = [
 
 from collections.abc import Iterator, Sequence
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 from urllib.parse import quote
@@ -92,7 +92,7 @@ def _process_one(f: Path):
 
         for row in conn.execute('SELECT * FROM sync_item_data WHERE corpus == 11'):  # this looks like 'Labeled' list
             ts = row['timestamp'] / 1000
-            created = datetime.fromtimestamp(ts, tz=timezone.utc)
+            created = datetime.fromtimestamp(ts, tz=UTC)
 
             server_id = row['server_id']
             [item_type, item_id] = server_id.split(':')
@@ -134,10 +134,10 @@ def _process_one(f: Path):
                 note = None
 
             # TODO double check timezone
-            created = datetime.fromtimestamp(msg.f1.created.seconds, tz=timezone.utc).replace(microsecond=msg.f1.created.nanos // 1000)
+            created = datetime.fromtimestamp(msg.f1.created.seconds, tz=UTC).replace(microsecond=msg.f1.created.nanos // 1000)
 
             # NOTE: this one seems to be the same as row['timestamp']
-            updated = datetime.fromtimestamp(msg.f1.updated.seconds, tz=timezone.utc).replace(microsecond=msg.f1.updated.nanos // 1000)
+            updated = datetime.fromtimestamp(msg.f1.updated.seconds, tz=UTC).replace(microsecond=msg.f1.updated.nanos // 1000)
 
             address = msg.f2.addr1  # NOTE: there is also addr2, but they seem identical :shrug:
             if address == '':

--- a/src/my/hackernews/dogsheep.py
+++ b/src/my/hackernews/dogsheep.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from collections.abc import Iterator, Sequence
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 
 import my.config
@@ -57,7 +57,7 @@ def items() -> Iterator[Res[Item]]:
             yield Item(
                 id=r['id'],
                 type=r['type'],
-                created=datetime.fromtimestamp(r['time'], tz=timezone.utc),
+                created=datetime.fromtimestamp(r['time'], tz=UTC),
                 title=r['title'],
                 # todo hmm maybe a method to strip off html tags would be nice
                 text_html=r['text'],

--- a/src/my/hackernews/harmonic.py
+++ b/src/my/hackernews/harmonic.py
@@ -8,7 +8,7 @@ REQUIRES = ['lxml', 'orjson']
 
 from collections.abc import Iterator, Sequence
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, TypedDict, cast
 
@@ -65,7 +65,7 @@ class Saved(SavedBase):
     @property
     def when(self) -> datetime_aware:
         ts = self.raw['created_at_i']
-        return datetime.fromtimestamp(ts, tz=timezone.utc)
+        return datetime.fromtimestamp(ts, tz=UTC)
 
     @property
     def uid(self) -> str:

--- a/src/my/hackernews/materialistic.py
+++ b/src/my/hackernews/materialistic.py
@@ -3,7 +3,7 @@
 """
 
 from collections.abc import Iterator, Sequence
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, NamedTuple
 
@@ -36,7 +36,7 @@ class Saved(NamedTuple):
     @property
     def when(self) -> datetime_aware:
         ts = int(self.row['time']) / 1000
-        return datetime.fromtimestamp(ts, tz=timezone.utc)
+        return datetime.fromtimestamp(ts, tz=UTC)
 
     @property
     def uid(self) -> str:

--- a/src/my/instagram/android.py
+++ b/src/my/instagram/android.py
@@ -9,6 +9,7 @@ from collections.abc import Iterator, Sequence
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
+from typing import assert_never
 
 from my.core import (
     Json,
@@ -21,7 +22,6 @@ from my.core import (
 )
 from my.core.cachew import mcachew
 from my.core.common import unique_everseen
-from my.core.compat import add_note, assert_never
 from my.core.json import json_loads
 from my.core.sqlite import select, sqlite_connect_immutable
 
@@ -195,7 +195,7 @@ def _process_db(db: sqlite3.Connection) -> Iterator[Res[User | _Message]]:
             if m is not None:
                 yield m
         except Exception as e:
-            add_note(e, f'^ while parsing {j}')
+            e.add_note(f'^ while parsing {j}')
             yield e
 
 
@@ -212,10 +212,10 @@ def _entities() -> Iterator[Res[User | _Message]]:
             try:
                 for m in _process_db(db=db):
                     if isinstance(m, Exception):
-                        add_note(m, f'^ while processing {path}')
+                        m.add_note(f'^ while processing {path}')
                     yield m
             except Exception as e:
-                add_note(e, f'^ while processing {path}')
+                e.add_note(f'^ while processing {path}')
                 yield e
                 # todo use error policy here
 

--- a/src/my/instagram/gdpr.py
+++ b/src/my/instagram/gdpr.py
@@ -10,6 +10,7 @@ from collections.abc import Iterator, Sequence
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
+from typing import assert_never
 
 from more_itertools import bucket, spy
 
@@ -22,7 +23,6 @@ from my.core import (
     make_logger,
 )
 from my.core.common import unique_everseen
-from my.core.compat import add_note, assert_never
 
 from my.config import instagram as user_config  # isort: skip
 
@@ -216,7 +216,7 @@ def _entitites_from_path(path: Path) -> Iterator[Res[User | _Message]]:
                 try:
                     yield _parse_message(jm)
                 except Exception as e:
-                    add_note(e, f'^ while parsing {jm}')
+                    e.add_note(f'^ while parsing {jm}')
                     yield e
 
 
@@ -234,7 +234,7 @@ def messages() -> Iterator[Res[Message]]:
             try:
                 user = id2user[x.user_id]
             except Exception as e:
-                add_note(e, f'^ while processing {x}')
+                e.add_note(f'^ while processing {x}')
                 yield e
                 continue
             yield Message(

--- a/src/my/lastfm.py
+++ b/src/my/lastfm.py
@@ -5,7 +5,7 @@ Last.fm scrobbles
 from abc import abstractmethod
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Protocol
 
@@ -52,7 +52,7 @@ class Scrobble:
     @property
     def dt(self) -> datetime_aware:
         ts = int(self.raw['date'])
-        return datetime.fromtimestamp(ts, tz=timezone.utc)
+        return datetime.fromtimestamp(ts, tz=UTC)
 
     @property
     def artist(self) -> str:

--- a/src/my/location/fallback/common.py
+++ b/src/my/location/fallback/common.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Iterator, Sequence
 from dataclasses import dataclass
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 
 from ..common import Location, LocationProtocol
 
@@ -79,7 +79,7 @@ def _datetime_timestamp(dt: DateExact) -> float:
             return dt.timestamp()
         except ValueError:
             # https://github.com/python/cpython/issues/75395
-            return dt.replace(tzinfo=timezone.utc).timestamp()
+            return dt.replace(tzinfo=UTC).timestamp()
     return float(dt)
 
 def _iter_estimate_from(

--- a/src/my/location/fallback/via_home.py
+++ b/src/my/location/fallback/via_home.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from collections.abc import Iterator, Sequence
 from dataclasses import dataclass
-from datetime import datetime, time, timezone
+from datetime import UTC, datetime, time
 from functools import cache
 from typing import cast
 
@@ -50,7 +50,7 @@ class Config(user_config):
                 dt = datetime.combine(x, time.min)
             # todo not sure about doing it here, but makes it easier to compare..
             if dt.tzinfo is None:
-                dt = dt.replace(tzinfo=timezone.utc)
+                dt = dt.replace(tzinfo=UTC)
             res.append((dt, loc))
         res = sorted(res, key=lambda p: p[0])
         return res
@@ -87,7 +87,7 @@ def estimate_location(dt: DateExact) -> Iterator[FallbackLocation]:
                 lat=lat,
                 lon=lon,
                 accuracy=config.home_accuracy,
-                dt=datetime.fromtimestamp(d, timezone.utc),
+                dt=datetime.fromtimestamp(d, UTC),
                 datasource='via_home')
             return
 
@@ -97,5 +97,5 @@ def estimate_location(dt: DateExact) -> Iterator[FallbackLocation]:
         lat=lat,
         lon=lon,
         accuracy=config.home_accuracy,
-        dt=datetime.fromtimestamp(d, timezone.utc),
+        dt=datetime.fromtimestamp(d, UTC),
         datasource='via_home')

--- a/src/my/location/google.py
+++ b/src/my/location/google.py
@@ -12,7 +12,7 @@ REQUIRES = [
 
 import re
 from collections.abc import Iterable, Sequence
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from itertools import islice
 from pathlib import Path
 from subprocess import PIPE, Popen
@@ -54,7 +54,7 @@ def _iter_via_ijson(fo) -> Iterable[TsLatLon]:
         warnings.medium("Falling back to default ijson because 'cffi' backend isn't found. It's up to 2x faster, you might want to check it out")
         import ijson  # type: ignore[import-untyped]
 
-    for d in ijson.items(fo, 'locations.item'):
+    for d in ijson.items(fo, 'locations.item'):  # ty: ignore[possibly-missing-attribute]
         yield (
             int(d['timestampMs']),
             d['latitudeE7' ],
@@ -88,7 +88,7 @@ def _iter_locations_fo(fit) -> Iterable[Location]:
     errors = 0
 
     for tsMs, latE7, lonE7 in fit:
-        dt = datetime.fromtimestamp(tsMs / 1000, tz=timezone.utc)
+        dt = datetime.fromtimestamp(tsMs / 1000, tz=UTC)
         total += 1
         if total % 10000 == 0:
             logger.info('processing item %d %s', total, dt)

--- a/src/my/location/gpslogger.py
+++ b/src/my/location/gpslogger.py
@@ -7,7 +7,7 @@ REQUIRES = ["gpxpy"]
 
 from collections.abc import Iterator, Sequence
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from itertools import chain
 from pathlib import Path
 
@@ -81,7 +81,7 @@ def _extract_locations(path: Path) -> Iterator[Location]:
                         lon=point.longitude,
                         accuracy=config.accuracy,
                         elevation=point.elevation,
-                        dt=datetime.replace(point.time, tzinfo=timezone.utc),
+                        dt=datetime.replace(point.time, tzinfo=UTC),
                         datasource="gpslogger",
                     )
 

--- a/src/my/pdfs.py
+++ b/src/my/pdfs.py
@@ -19,7 +19,6 @@ from more_itertools import bucket
 
 from my.core import PathIsh, Paths, Stats, get_files, make_logger, stat
 from my.core.cachew import mcachew
-from my.core.compat import add_note
 from my.core.error import Res, split_errors
 
 
@@ -135,7 +134,7 @@ def _iter_annotations(pdfs: Sequence[Path]) -> Iterator[Res[Annotation]]:
             try:
                 yield from f.result()
             except Exception as e:
-                add_note(e, f'^ while processing {pdf}')
+                e.add_note(f'^ while processing {pdf}')
                 logger.exception(e)
                 # todo add a comment that it can be ignored... or something like that
                 # TODO not sure if should attach pdf as well; it's a bit annoying to pass around?

--- a/src/my/podcastaddict/android.py
+++ b/src/my/podcastaddict/android.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from abc import abstractmethod
 from collections.abc import Iterable, Iterator, Sequence
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from itertools import chain
 from pathlib import Path
 from typing import Protocol
@@ -167,7 +167,7 @@ class Status:
         if pb == -1:
             # todo might be nice to tell apart from None case?
             return None
-        return datetime.fromtimestamp(pb / 1000, tz=timezone.utc)
+        return datetime.fromtimestamp(pb / 1000, tz=UTC)
 
     @property
     def position_to_resume(self) -> int | None:
@@ -203,7 +203,7 @@ class Episode:
     def publication_dt(self) -> datetime:
         # todo not 100% sure if it's UTC?
         # tricky to find out for sure, the app doesn't show podcast publication time..
-        return datetime.fromtimestamp(self.row['publication_date'] / 1000, tz=timezone.utc)
+        return datetime.fromtimestamp(self.row['publication_date'] / 1000, tz=UTC)
 
     @property
     def short_description(self) -> str:

--- a/src/my/polar.py
+++ b/src/my/polar.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import json
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
+from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, NamedTuple, cast
 
@@ -19,7 +20,6 @@ from my.core import (
     make_config,
     make_logger,
 )
-from my.core.compat import add_note, fromisoformat
 from my.core.error import sort_res_by
 from my.core.konsume import Wdict, Zoomable, wrap
 
@@ -158,7 +158,7 @@ class Loader:
             cmap[hlid] = ccs
             comment = Comment(
                 cid=cid.value,
-                created=fromisoformat(crt.value),
+                created=datetime.fromisoformat(crt.value),
                 text=html.value,  # TODO perhaps coonvert from html to text or org?
             )
             ccs.append(comment)
@@ -197,7 +197,7 @@ class Loader:
 
             yield Highlight(
                 hid=hid,
-                created=fromisoformat(crt),
+                created=datetime.fromisoformat(crt),
                 selection=text,
                 comments=tuple(comments),
                 tags=tuple(htags),
@@ -234,7 +234,7 @@ class Loader:
         path = Path(config.polar_dir) / 'stash' / filename
 
         yield Book(
-            created=fromisoformat(added),
+            created=datetime.fromisoformat(added),
             uid=self.uid,
             path=path,
             title=title,
@@ -249,7 +249,7 @@ def iter_entries() -> Iterable[Result]:
         try:
             yield from loader.load()
         except Exception as e:
-            add_note(e, f'^ while processing {d}')
+            e.add_note(f'^ while processing {d}')
             yield e
 
 

--- a/src/my/roamresearch.py
+++ b/src/my/roamresearch.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import re
 from collections.abc import Iterator
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from itertools import chain
 from pathlib import Path
 from typing import NamedTuple
@@ -39,7 +39,7 @@ class Node(NamedTuple):
     def created(self) -> datetime:
         ct = self.raw.get(Keys.CREATED)
         if ct is not None:
-            return datetime.fromtimestamp(ct / 1000, tz=timezone.utc)
+            return datetime.fromtimestamp(ct / 1000, tz=UTC)
         # ugh. daily notes don't have create time for some reason???
 
         title = self.title
@@ -51,13 +51,13 @@ class Node(NamedTuple):
             return self.edited # fallback TODO log?
         # strip off 'th'/'rd' crap
         dts = m.group(1) + ' ' + m.group(2) + ' ' + m.group(3)
-        dt = datetime.strptime(dts, '%B %d %Y').replace(tzinfo=timezone.utc)
+        dt = datetime.strptime(dts, '%B %d %Y').replace(tzinfo=UTC)
         return dt
 
     @property
     def edited(self) -> datetime:
         rt = self.raw[Keys.EDITED]
-        return datetime.fromtimestamp(rt / 1000, tz=timezone.utc)
+        return datetime.fromtimestamp(rt / 1000, tz=UTC)
 
     @property
     def title(self) -> str | None:

--- a/src/my/rss/feedbin.py
+++ b/src/my/rss/feedbin.py
@@ -4,10 +4,10 @@ Feedbin RSS reader
 
 import json
 from collections.abc import Iterator, Sequence
+from datetime import datetime
 from pathlib import Path
 
 from my.core import Stats, get_files, stat
-from my.core.compat import fromisoformat
 
 from .common import Subscription, SubscriptionState
 
@@ -21,7 +21,7 @@ def parse_file(f: Path) -> Iterator[Subscription]:
     raw = json.loads(f.read_text())
     for r in raw:
         yield Subscription(
-            created_at=fromisoformat(r['created_at']),
+            created_at=datetime.fromisoformat(r['created_at']),
             title=r['title'],
             url=r['site_url'],
             id=r['id'],
@@ -32,7 +32,7 @@ def states() -> Iterator[SubscriptionState]:
     for f in inputs():
         # TODO ugh. depends on my naming. not sure if useful?
         dts = f.stem.split('_')[-1]
-        dt = fromisoformat(dts)
+        dt = datetime.fromisoformat(dts)
         subs = list(parse_file(f))
         yield dt, subs
 

--- a/src/my/rss/feedly.py
+++ b/src/my/rss/feedly.py
@@ -5,7 +5,7 @@ Feedly RSS reader
 import json
 from abc import abstractmethod
 from collections.abc import Iterator, Sequence
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Protocol
 
@@ -51,6 +51,6 @@ def parse_file(f: Path) -> Iterator[Subscription]:
 def states() -> Iterator[SubscriptionState]:
     for f in inputs():
         dts = f.stem.split('_')[-1]
-        dt = datetime.strptime(dts, '%Y%m%d%H%M%S').replace(tzinfo=timezone.utc)
+        dt = datetime.strptime(dts, '%Y%m%d%H%M%S').replace(tzinfo=UTC)
         subs = list(parse_file(f))
         yield dt, subs

--- a/src/my/runnerup.py
+++ b/src/my/runnerup.py
@@ -7,14 +7,13 @@ REQUIRES = [
 ]
 
 from collections.abc import Iterable
-from datetime import timedelta
+from datetime import datetime, timedelta
 from pathlib import Path
 
 import tcxparser  # type: ignore[import-untyped]
 
 from my.config import runnerup as config
 from my.core import Json, Res, get_files
-from my.core.compat import fromisoformat
 
 # TODO later, use a proper namedtuple?
 Workout = Json
@@ -42,7 +41,7 @@ def _parse(f: Path) -> Workout:
 
     return {
         'id'            : f.name, # not sure?
-        'start_time'    : fromisoformat(tcx.started_at),
+        'start_time'    : datetime.fromisoformat(tcx.started_at),
         'duration'      : timedelta(seconds=tcx.duration),
         'sport'         : sport,
         'heart_rate_avg': tcx.hr_avg,

--- a/src/my/smscalls.py
+++ b/src/my/smscalls.py
@@ -24,7 +24,7 @@ from my.core.cfg import make_config
 config = make_config(smscalls)
 
 from collections.abc import Iterator
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, NamedTuple
 
@@ -318,7 +318,7 @@ def _extract_mms(path: Path) -> Iterator[Res[MMS]]:
 # See https://github.com/karlicoss/HPI/pull/90#issuecomment-702422351
 # for potentially parsing timezone from the readable_date
 def _parse_dt_ms(d: str) -> datetime:
-    return datetime.fromtimestamp(int(d) / 1000, tz=timezone.utc)
+    return datetime.fromtimestamp(int(d) / 1000, tz=UTC)
 
 
 def stats() -> Stats:

--- a/src/my/stackexchange/gdpr.py
+++ b/src/my/stackexchange/gdpr.py
@@ -4,13 +4,16 @@ Stackexchange data (uses [[https://stackoverflow.com/legal/gdpr/request][officia
 
 # TODO need to merge gdpr and stexport
 
-### config
+from collections.abc import Iterable
 from dataclasses import dataclass
+from datetime import datetime
+from typing import NamedTuple
 
 from my.config import stackexchange as user_config
 from my.core import Json, PathIsh, get_files, make_config
 
 
+### config
 @dataclass
 class stackexchange(user_config):
     gdpr_path: PathIsh  # path to GDPR zip file
@@ -20,12 +23,6 @@ config = make_config(stackexchange)
 
 # TODO just merge all of them and then filter?.. not sure
 
-from collections.abc import Iterable
-from datetime import datetime
-from typing import NamedTuple
-
-from my.core.compat import fromisoformat
-
 
 class Vote(NamedTuple):
     j: Json
@@ -33,7 +30,7 @@ class Vote(NamedTuple):
 
     @property
     def when(self) -> datetime:
-        return fromisoformat(self.j['eventTime'])
+        return datetime.fromisoformat(self.j['eventTime'])
 
     # todo Url return type?
     @property

--- a/src/my/telegram/telegram_backup.py
+++ b/src/my/telegram/telegram_backup.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import sqlite3
 from collections.abc import Iterator
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from struct import calcsize, unpack_from
 
 from my.config import telegram as user_config
@@ -68,7 +68,7 @@ def _message_from_row(r: sqlite3.Row, *, chats: Chats, with_extra_media_info: bo
     ts = r['time']
     # desktop export uses UTC (checked by exporting in winter time vs summer time)
     # and telegram_backup timestamps seem same as in desktop export
-    time = datetime.fromtimestamp(ts, tz=timezone.utc)
+    time = datetime.fromtimestamp(ts, tz=UTC)
     chat = chats[r['source_id']]
     sender = chats[r['sender_id']]
 

--- a/src/my/tests/location/fallback.py
+++ b/src/my/tests/location/fallback.py
@@ -3,7 +3,7 @@ To test my.location.fallback_location.all
 """
 
 from collections.abc import Iterator
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 
 import pytest
 from more_itertools import ilen
@@ -30,32 +30,30 @@ def test_ip_fallback() -> None:
     # basic tests
 
     # try estimating slightly before the first IP
-    est = list(via_ip.estimate_location(datetime(2020, 1, 1, 11, 59, 59, tzinfo=timezone.utc)))
+    est = list(via_ip.estimate_location(datetime(2020, 1, 1, 11, 59, 59, tzinfo=UTC)))
     assert len(est) == 0
 
     # during the duration for the first IP
-    est = list(via_ip.estimate_location(datetime(2020, 1, 1, 12, 30, 0, tzinfo=timezone.utc)))
+    est = list(via_ip.estimate_location(datetime(2020, 1, 1, 12, 30, 0, tzinfo=UTC)))
     assert len(est) == 1
 
     # right after the 'for_duration' for an IP
-    est = list(
-        via_ip.estimate_location(datetime(2020, 1, 1, 12, 0, 0, tzinfo=timezone.utc) + via_ip.config.for_duration + timedelta(seconds=1))
-    )
+    est = list(via_ip.estimate_location(datetime(2020, 1, 1, 12, 0, 0, tzinfo=UTC) + via_ip.config.for_duration + timedelta(seconds=1)))
     assert len(est) == 0
 
     # on 2/1/2020, threes one IP if before 16:30
-    est = list(via_ip.estimate_location(datetime(2020, 2, 1, 12, 30, 0, tzinfo=timezone.utc)))
+    est = list(via_ip.estimate_location(datetime(2020, 2, 1, 12, 30, 0, tzinfo=UTC)))
     assert len(est) == 1
 
     # and two if after 16:30
-    est = list(via_ip.estimate_location(datetime(2020, 2, 1, 17, 00, 0, tzinfo=timezone.utc)))
+    est = list(via_ip.estimate_location(datetime(2020, 2, 1, 17, 00, 0, tzinfo=UTC)))
     assert len(est) == 2
 
     # the 12:30 IP should 'expire' before the 16:30 IP, use 3:30PM on the next day
-    est = list(via_ip.estimate_location(datetime(2020, 2, 2, 15, 30, 0, tzinfo=timezone.utc)))
+    est = list(via_ip.estimate_location(datetime(2020, 2, 2, 15, 30, 0, tzinfo=UTC)))
     assert len(est) == 1
 
-    use_dt = datetime(2020, 3, 1, 12, 15, 0, tzinfo=timezone.utc)
+    use_dt = datetime(2020, 3, 1, 12, 15, 0, tzinfo=UTC)
 
     # test last IP
     est = list(via_ip.estimate_location(use_dt))
@@ -105,11 +103,11 @@ def test_ip_fallback() -> None:
     assert all_est.datasource == "via_ip"
 
     # test that a home defined in shared_tz_config.py is used if no IP is found
-    loc = all.estimate_location(datetime(2021, 1, 1, 12, 30, 0, tzinfo=timezone.utc))
+    loc = all.estimate_location(datetime(2021, 1, 1, 12, 30, 0, tzinfo=UTC))
     assert loc.datasource == "via_home"
 
     # test a different home using location.fallback.all
-    bulgaria = all.estimate_location(datetime(2006, 1, 1, 12, 30, 0, tzinfo=timezone.utc))
+    bulgaria = all.estimate_location(datetime(2006, 1, 1, 12, 30, 0, tzinfo=UTC))
     assert bulgaria.datasource == "via_home"
     assert (bulgaria.lat, bulgaria.lon) == (42.697842, 23.325973)
     assert (loc.lat, loc.lon) != (bulgaria.lat, bulgaria.lon)
@@ -117,11 +115,11 @@ def test_ip_fallback() -> None:
 
 def data() -> Iterator[IP]:
     # random IP addresses
-    yield IP(addr="67.98.113.0", dt=datetime(2020, 1, 1, 12, 0, 0, tzinfo=timezone.utc))
-    yield IP(addr="67.98.112.0", dt=datetime(2020, 1, 15, 12, 0, 0, tzinfo=timezone.utc))
-    yield IP(addr="59.40.113.87", dt=datetime(2020, 2, 1, 12, 0, 0, tzinfo=timezone.utc))
-    yield IP(addr="59.40.139.87", dt=datetime(2020, 2, 1, 16, 0, 0, tzinfo=timezone.utc))
-    yield IP(addr="161.235.192.228", dt=datetime(2020, 3, 1, 12, 0, 0, tzinfo=timezone.utc))
+    yield IP(addr="67.98.113.0", dt=datetime(2020, 1, 1, 12, 0, 0, tzinfo=UTC))
+    yield IP(addr="67.98.112.0", dt=datetime(2020, 1, 15, 12, 0, 0, tzinfo=UTC))
+    yield IP(addr="59.40.113.87", dt=datetime(2020, 2, 1, 12, 0, 0, tzinfo=UTC))
+    yield IP(addr="59.40.139.87", dt=datetime(2020, 2, 1, 16, 0, 0, tzinfo=UTC))
+    yield IP(addr="161.235.192.228", dt=datetime(2020, 3, 1, 12, 0, 0, tzinfo=UTC))
 
 
 @pytest.fixture(autouse=True)

--- a/src/my/tests/reddit.py
+++ b/src/my/tests/reddit.py
@@ -15,7 +15,7 @@ def test_basic_1() -> None:
     # todo maybe this should call stat or something instead?
     # would ensure reasonable stat implementation as well and less duplication
     # note: deliberately use old module (instead of my.reddit.all) to test bwd compatibility
-    from my.reddit import saved
+    from my.reddit import saved  # ty: ignore[possibly-missing-import]
 
     assert len(list(saved())) > 0
 
@@ -43,7 +43,7 @@ def test_saves() -> None:
 def test_preserves_extra_attr() -> None:
     # doesn't strictly belong here (not specific to reddit)
     # but my.reddit does a fair bit of dynamic hacking, so perhaps a good place to check nothing is lost
-    from my.reddit import config
+    from my.reddit import config  # ty: ignore[possibly-missing-import]
 
     assert isinstance(getattr(config, 'please_keep_me'), str)
 

--- a/src/my/tests/shared_tz_config.py
+++ b/src/my/tests/shared_tz_config.py
@@ -2,7 +2,7 @@
 Helper to test various timezone/location dependent things
 """
 
-from datetime import date, datetime, timezone
+from datetime import UTC, date, datetime
 from pathlib import Path
 
 import pytest
@@ -20,16 +20,14 @@ def config(tmp_path: Path):
         takeout_path = _takeout_path
 
     class location:
-        # fmt: off
         home = (
             # supports ISO strings
-            ('2005-12-04'                                       , (42.697842, 23.325973)), # Bulgaria, Sofia
+            ('2005-12-04'                              , (42.697842, 23.325973)), # Bulgaria, Sofia
             # supports date/datetime objects
-            (date(year=1980, month=2, day=15)                   , (40.7128  , -74.0060 )), # NY
+            (date(year=1980, month=2, day=15)          , (40.7128  , -74.0060 )), # NY
             # check tz handling..
-            (datetime.fromtimestamp(1600000000, tz=timezone.utc), (55.7558  , 37.6173  )), # Moscow, Russia
-        )
-        # fmt: on
+            (datetime.fromtimestamp(1600000000, tz=UTC), (55.7558  , 37.6173  )), # Moscow, Russia
+        )  # fmt: skip
         # note: order doesn't matter, will be sorted in the data provider
 
     class time:

--- a/src/my/tests/twitter/archive.py
+++ b/src/my/tests/twitter/archive.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 from my.twitter.archive import Tweet
 
@@ -53,7 +53,7 @@ def test_tweet() -> None:
     """.strip()
     t = Tweet(json.loads(raw), screen_name='whatever')
     assert t.permalink == 'https://twitter.com/whatever/status/1269253350735982592'
-    assert t.dt == datetime(2020, 6, 6, 13, 2, 35, tzinfo=timezone.utc)
+    assert t.dt == datetime(2020, 6, 6, 13, 2, 35, tzinfo=UTC)
     assert (
         t.text
         == 'Finally published the post about Promnesia: https://beepb00p.xyz/promnesia.html\n\nA story of how our browser history is broken and my attempt to fix it!'

--- a/src/my/tests/tz.py
+++ b/src/my/tests/tz.py
@@ -7,7 +7,6 @@ import pytz
 import my.time.tz.main as tz_main
 import my.time.tz.via_location as tz_via_location
 from my.core import notnone
-from my.core.compat import fromisoformat
 
 from .shared_tz_config import config  # noqa: F401  # autoused fixture
 
@@ -47,7 +46,7 @@ def test_past() -> None:
     """
     Should fallback to the 'home' location provider
     """
-    dt = fromisoformat('2000-01-01 12:34:45')
+    dt = datetime.fromisoformat('2000-01-01 12:34:45')
     dt = tz_main.localize(dt)
     assert getzone(dt) == 'America/New_York'
 
@@ -66,16 +65,16 @@ def test_get_tz(config) -> None:
     get_tz = tz_via_location.get_tz
 
     # not present in the test data
-    tz = get_tz(fromisoformat('2020-01-01 10:00:00'))
+    tz = get_tz(datetime.fromisoformat('2020-01-01 10:00:00'))
     assert notnone(tz).zone == 'Europe/Sofia'
 
-    tz = get_tz(fromisoformat('2017-08-01 11:00:00'))
+    tz = get_tz(datetime.fromisoformat('2017-08-01 11:00:00'))
     assert notnone(tz).zone == 'Europe/Vienna'
 
-    tz = get_tz(fromisoformat('2017-07-30 10:00:00'))
+    tz = get_tz(datetime.fromisoformat('2017-07-30 10:00:00'))
     assert notnone(tz).zone == 'Europe/Rome'
 
-    tz = get_tz(fromisoformat('2020-10-01 14:15:16'))
+    tz = get_tz(datetime.fromisoformat('2020-10-01 14:15:16'))
     assert tz is not None
 
     on_windows = sys.platform == 'win32'
@@ -90,7 +89,7 @@ def test_get_tz(config) -> None:
 
 
 def test_policies() -> None:
-    naive = fromisoformat('2017-07-30 10:00:00')
+    naive = datetime.fromisoformat('2017-07-30 10:00:00')
     assert naive.tzinfo is None  # just in case
 
     # actual timezone at the time

--- a/src/my/topcoder.py
+++ b/src/my/topcoder.py
@@ -1,11 +1,11 @@
 import json
 from collections.abc import Iterator, Sequence
 from dataclasses import dataclass
+from datetime import datetime
 from functools import cached_property
 from pathlib import Path
 
 from my.core import Res, datetime_aware, get_files
-from my.core.compat import fromisoformat
 from my.experimental.destructive_parsing import Manager
 
 from my.config import topcoder as config  # type: ignore[attr-defined]  # isort: skip
@@ -28,7 +28,7 @@ class Competition:
 
     @cached_property
     def when(self) -> datetime_aware:
-        return fromisoformat(self.date_str)
+        return datetime.fromisoformat(self.date_str)
 
     @classmethod
     def make(cls, j) -> Iterator[Res['Competition']]:

--- a/src/my/twitter/android.py
+++ b/src/my/twitter/android.py
@@ -8,7 +8,7 @@ import re
 import sqlite3
 from collections.abc import Iterator, Sequence
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from struct import unpack_from
 
@@ -288,7 +288,7 @@ def _process_one(f: Path, *, where: str) -> Iterator[Res[Tweet]]:
                 yield Tweet(
                     id_str=tweet_id,
                     # TODO double check it's utc?
-                    created_at=datetime.fromtimestamp(created_ms / 1000, tz=timezone.utc),
+                    created_at=datetime.fromtimestamp(created_ms / 1000, tz=UTC),
                     screen_name=user_username,
                     text=content,
                 )

--- a/src/my/twitter/talon.py
+++ b/src/my/twitter/talon.py
@@ -9,7 +9,7 @@ import sqlite3
 from abc import abstractmethod
 from collections.abc import Iterator, Sequence
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 
 from my.core import Paths, Res, datetime_aware, get_files
@@ -108,7 +108,7 @@ def _parse_tweet(row: sqlite3.Row) -> Tweet:
     # uses https://docs.oracle.com/javase/7/docs/api/java/util/Date.html#getTime()
     # and it's created here, so looks like it's properly parsed from the api
     # https://github.com/Twitter4J/Twitter4J/blob/8376fade8d557896bb9319fb46e39a55b134b166/twitter4j-core/src/internal-json/java/twitter4j/ParseUtil.java#L69-L79
-    created_at = datetime.fromtimestamp(row['time'] / 1000, tz=timezone.utc)
+    created_at = datetime.fromtimestamp(row['time'] / 1000, tz=UTC)
     text = row['text']
 
     # try explanding URLs.. sadly there are no positions in the db

--- a/src/my/twitter/twint.py
+++ b/src/my/twitter/twint.py
@@ -3,7 +3,7 @@ Twitter data (tweets and favorites). Uses [[https://github.com/twintproject/twin
 """
 from collections.abc import Iterator
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import NamedTuple
 
@@ -53,7 +53,7 @@ class Tweet(NamedTuple):
     @property
     def created_at(self) -> datetime_aware:
         seconds = self.row['created_at'] / 1000
-        tz = timezone.utc
+        tz = UTC
         # NOTE: UTC seems to be the case at least for the older version of schema I was using
         # in twint, it was extracted from "data-time-ms" field in the scraped HML
         # https://github.com/twintproject/twint/blob/e3345426eb24154ff084be22e4fed5cfa4631930/twint/tweet.py#L85

--- a/src/my/vk/favorites.py
+++ b/src/my/vk/favorites.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import json
 from collections.abc import Iterable, Iterator
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 from my.config import vk as config  # type: ignore[attr-defined]
 from my.core import Json, Stats, datetime_aware, stat
@@ -47,7 +47,7 @@ def parse_fav(j: Json) -> Favorite:
 
     # TODO would be nice to include user
     return Favorite(
-        dt=datetime.fromtimestamp(j['date'], tz=timezone.utc),
+        dt=datetime.fromtimestamp(j['date'], tz=UTC),
         title=title,
         url=url,
         text=j['text'],

--- a/src/my/whatsapp/android.py
+++ b/src/my/whatsapp/android.py
@@ -7,12 +7,11 @@ from __future__ import annotations
 import sqlite3
 from collections.abc import Iterator, Sequence
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 
 from my.core import Paths, Res, datetime_aware, get_files, make_config, make_logger
 from my.core.common import unique_everseen
-from my.core.compat import add_note
 from my.core.error import notnone
 from my.core.sqlite import sqlite_connection
 
@@ -143,7 +142,7 @@ def _process_db(db: sqlite3.Connection) -> Iterator[Entity]:
     ):
         msg_id: str = notnone(r['key_id'])
         ts: int = notnone(r['timestamp'])
-        dt = datetime.fromtimestamp(ts / 1000, tz=timezone.utc)
+        dt = datetime.fromtimestamp(ts / 1000, tz=UTC)
 
         text: str | None = r['text_data']
         media_file_path: str | None = r['file_path']
@@ -222,7 +221,7 @@ def _entities() -> Iterator[Res[Entity]]:
             try:
                 yield from _process_db(db)
             except Exception as e:
-                add_note(e, f'^ while processing {path}')
+                e.add_note(f'^ while processing {path}')
 
 
 def entities() -> Iterator[Res[Entity]]:

--- a/src/my/zotero.py
+++ b/src/my/zotero.py
@@ -4,7 +4,7 @@ import json
 import sqlite3
 from collections.abc import Iterator, Sequence
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -175,7 +175,7 @@ def _parse_annotation(r: dict) -> Annotation:
     # fmt: on
 
     added = datetime.strptime(addeds, '%Y-%m-%d %H:%M:%S')
-    added = added.replace(tzinfo=timezone.utc)
+    added = added.replace(tzinfo=UTC)
 
     item = Item(
         file=Path(path),  # path is a bit misleading... could mean some internal DOM path?

--- a/src/my/zulip/organization.py
+++ b/src/my/zulip/organization.py
@@ -8,9 +8,10 @@ import json
 from abc import abstractmethod
 from collections.abc import Iterator, Sequence
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from itertools import count
 from pathlib import Path
+from typing import assert_never
 
 from my.core import (
     Json,
@@ -23,7 +24,6 @@ from my.core import (
     stat,
     warnings,
 )
-from my.core.compat import assert_never
 
 logger = make_logger(__name__)
 
@@ -163,7 +163,7 @@ def _process_one(root: Path) -> Iterator[Res[Server | Sender | _Message]]:
         # fmt: off
         return _Message(
             id        = j['id'],
-            sent      = datetime.fromtimestamp(ds, tz=timezone.utc),
+            sent      = datetime.fromtimestamp(ds, tz=UTC),
             subject   = j['subject'],
             sender_id = j['sender'],
             server_id = server.id,

--- a/ty.toml
+++ b/ty.toml
@@ -4,6 +4,3 @@ exclude = [
 
 [rules]
 type-assertion-failure = "ignore"  # TODO many false positives for now, sort out later
-missing-argument = "ignore"  # typed dicts/kwargs unpacking triggers these a lot https://github.com/astral-sh/ty/issues/154
-possibly-unbound-import  = "ignore"  # my.config; sort out later
-possibly-unbound-attribute = "ignore"  # see https://github.com/astral-sh/ty/issues/623


### PR DESCRIPTION
It's a bit of a toll to support so many versions, especially with new 3.12 type syntax and other goodies. And 3.12 itself is 2+ years old.

With pyenv/uv these days using custom python version is far easier than before and even preferred.