### PR TITLE
core/config: resolve MY_CONFIG path before warning unrelatedness

### DIFF
--- a/src/my/core/init.py
+++ b/src/my/core/init.py
@@ -63,7 +63,7 @@ See https://github.com/karlicoss/HPI/blob/master/doc/SETUP.org#setting-up-the-mo
             used_config_path = Path(used_config_file)
             try:
                 # will crash if it's imported from other dir?
-                used_config_path.relative_to(mycfg_dir)
+                used_config_path.resolve().relative_to(mycfg_dir.resolve())
             except ValueError:
                 # TODO maybe implement a strict mode where these warnings will be errors?
                 warnings.warn(


### PR DESCRIPTION
PR #336 added a warning for when the detected `my.config` module is not in a subpath of `MY_CONFIG`. This was to help diagnose bad setups.

This warning is currently faulty. Because the paths aren't resolved before comparison, setting `MY_CONFIG` to a relative value like `./config` will fail the check despite the config module existing within the current working directory. (Using relative values for the env might be seen with a directory-sandboxed HPI setup, using something like direnv)

```
Expected my.config to be located at ./config, but instead its path is <someabsolutepath>\config\my\config\__init__.py.
This will likely cause issues down the line -- double check ./config structure.
```

The pull request resolves both paths used in the comparison to the absolute path. The problem described above is fixed, which I verified with a locally editable install.