### PR TITLE
Filter non-watch YouTube Takeout activity

### DIFF
--- a/src/my/tests/youtube.py
+++ b/src/my/tests/youtube.py
@@ -1,0 +1,57 @@
+import sys
+from datetime import UTC, datetime
+from types import ModuleType
+
+import pytest
+from google_takeout_parser.models import Activity
+
+from my.youtube.takeout import Watched, _is_youtube_video_url, _watched
+
+
+def _activity(*, title: str, url: str) -> Activity:
+    return Activity(
+        header='YouTube',
+        title=title,
+        time=datetime(2026, 7, 18, tzinfo=UTC),
+        description=None,
+        titleUrl=url,
+        subtitles=[],
+        details=[],
+        locationInfos=[],
+        products=['YouTube'],
+    )
+
+
+def test_youtube_video_urls() -> None:
+    assert _is_youtube_video_url('https://www.youtube.com/watch?v=video')
+    assert _is_youtube_video_url('https://youtube.com/watch?v=video')
+    assert _is_youtube_video_url('https://m.youtube.com/watch?v=video')
+    assert _is_youtube_video_url('https://www.youtube.com/shorts/short')
+    assert _is_youtube_video_url('https://www.youtube.com/watch?v=')
+    assert not _is_youtube_video_url('https://www.youtube.com/watch')
+    assert not _is_youtube_video_url('https://example.com/watch?v=video')
+
+
+def test_watched_filters_non_watch_activity(monkeypatch: pytest.MonkeyPatch) -> None:
+    activities = [
+        _activity(title='Watched A regular video', url='https://www.youtube.com/watch?v=video'),
+        _activity(title='Watched A short', url='https://www.youtube.com/shorts/short'),
+        _activity(title='Shared video', url='https://youtube.com/watch?v=shared'),
+        _activity(title='Shared shorts', url='https://youtube.com/shorts/shared'),
+        _activity(title='Joined YouTube Music', url='https://www.youtube.com'),
+        _activity(
+            title='Visited an advertiser',
+            url='https://www.google.com/url?q=https://example.com',
+        ),
+    ]
+    parser = ModuleType('my.google.takeout.parser')
+    setattr(parser, 'events', lambda: iter(activities))
+    monkeypatch.setitem(sys.modules, 'my.google.takeout.parser', parser)
+
+    results = list(_watched())
+
+    assert all(isinstance(result, Watched) for result in results)
+    assert [(result.title, result.url) for result in results if isinstance(result, Watched)] == [
+        ('A regular video', 'https://www.youtube.com/watch?v=video'),
+        ('A short', 'https://www.youtube.com/shorts/short'),
+    ]

--- a/src/my/youtube/takeout.py
+++ b/src/my/youtube/takeout.py
@@ -3,11 +3,23 @@ from __future__ import annotations
 from collections.abc import Iterable, Iterator
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
+from urllib.parse import parse_qs, urlparse
 
 from my.core import Res, Stats, datetime_aware, make_logger, stat, warnings
 from my.core.compat import deprecated
 
 logger = make_logger(__name__)
+
+
+def _is_youtube_video_url(url: str) -> bool:
+    parsed = urlparse(url)
+    if parsed.hostname not in {'youtube.com', 'www.youtube.com', 'm.youtube.com'}:
+        return False
+    if parsed.path == '/watch':
+        # Deleted/private videos can retain the ``v`` parameter without its
+        # value. They are still useful watch-history records.
+        return 'v' in parse_qs(parsed.query, keep_blank_values=True)
+    return parsed.path.startswith('/shorts/')
 
 
 @dataclass
@@ -75,8 +87,6 @@ def _watched() -> Iterator[Res[Watched]]:
         yield from _watched_legacy()  # type: ignore[name-defined]  # ty: ignore[invalid-yield]
         return
 
-    YOUTUBE_VIDEO_LINK = '://www.youtube.com/watch?v='
-
     # TODO would be nice to filter, e.g. it's kinda pointless to process Location events
     for e in events():
         if isinstance(e, Exception):
@@ -100,22 +110,17 @@ def _watched() -> Iterator[Res[Watched]]:
         if header not in {'YouTube', 'youtube.com'}:
             # TODO hmm -- wonder if these would end up in dupes in takeout? would be nice to check
             # perhaps this would be easier once we have universal ids
-            if YOUTUBE_VIDEO_LINK in url:
+            if _is_youtube_video_url(url):
                 # TODO maybe log in this case or something?
                 pass
             continue
 
         title = e.title
 
-        if header == 'youtube.com' and title.startswith('Visited '):
-            continue
-
-        if title.startswith('Searched for') and url.startswith('https://www.youtube.com/results'):
-            # search activity, don't need it here
-            continue
-
-        if title.startswith('Subscribed to') and url.startswith('https://www.youtube.com/channel/'):
-            # todo might be interesting to process somewhere?
+        # Search/ads, shares, subscriptions and account events can all be
+        # attributed to YouTube in My Activity. Only records explicitly marked
+        # as watched belong in watch history.
+        if not title.startswith('Watched '):
             continue
 
         # all titles contain it, so pointless to include 'Watched '
@@ -125,7 +130,7 @@ def _watched() -> Iterator[Res[Watched]]:
         # watches originating from some activity end with this, remove it for consistency
         title = title.removesuffix(' - YouTube')
 
-        if YOUTUBE_VIDEO_LINK not in url:
+        if not _is_youtube_video_url(url):
             if 'youtube.com/post/' in url:
                 # some sort of channel updates?
                 continue


### PR DESCRIPTION
## What changed

- recognize standard YouTube watch URLs across bare, `www`, and mobile hosts
- recognize YouTube Shorts as watch-history entries
- retain deleted/private watch records whose `v` parameter is present but blank
- require the Takeout activity title to explicitly identify a watch, so shares, reactions, advertiser visits, subscriptions, and account events are not emitted as `Watched`

## Root cause

The Takeout normalizer treated nearly every activity attributed to YouTube as watch history, then validated it with a literal `://www.youtube.com/watch?v=` substring. Current Takeout data includes Shorts and non-watch YouTube activities, so valid Shorts raised `RuntimeError` while unrelated activity was either raised as an error or silently counted as a watch.

## Impact

Consumers get a cleaner watch-history stream, including Shorts, without losing deleted/private-video placeholders.

## Checks

- `uv run --group testing --with google-takeout-parser pytest -o addopts='' -q src/my/tests/youtube.py` — 2 passed
- `uv run --group testing ruff check src/my/youtube/takeout.py src/my/tests/youtube.py` — passed
- `uv run --group testing ruff format --check src/my/youtube/takeout.py src/my/tests/youtube.py` — passed

Full private Takeout audit using the parser fix from purarue/google_takeout_parser#95:

- 350,849 parsed events; 0 parser errors
- before: 72,286 watches; 15 YouTube `RuntimeError`s
- after: 72,278 watches; 0 YouTube errors
- one valid Short recovered
- 14 erroring non-watch activities skipped
- 9 additional non-watch interactions no longer silently counted as watches
- all 7,142 deleted/private-video placeholders retained

The aggregate proof report contains no personal event content. SHA-256: `74f560123787827dcb96e10bda2d1508d17656d85bbe47bbbf77c96583f47048`.
