### PR TITLE
core: add experimental provider `dev snapshot` and `dev diff` commands

### DIFF
--- a/src/my/core/__main__.py
+++ b/src/my/core/__main__.py
@@ -752,6 +752,113 @@ def module_install_cmd(*, user: bool, parallel: bool, break_system_packages: boo
     module_install(user=user, module=modules, parallel=parallel, break_system_packages=break_system_packages)
 
 
+@main.group(name='dev', short_help='experimental developer tools')
+def dev_grp() -> None:
+    '''Experimental tools whose interfaces and file formats are not stable.'''
+    pass
+
+
+@dev_grp.command(name='snapshot', short_help='capture canonical JSONL provider output')
+@click.option(
+    '--key',
+    default=None,
+    type=str,
+    help='Dotted item field used as stable identity, for example id, author.id, or source.account.id',
+)
+@click.option(
+    '-o',
+    '--output',
+    required=True,
+    type=click.Path(path_type=Path, dir_okay=False),
+    help='Destination JSONL file.',
+)
+@click.option('--force', is_flag=True, help='Overwrite the destination if it already exists.')
+@click.argument('FUNCTION_NAME', type=str, shell_complete=_module_autocomplete)
+def dev_snapshot_cmd(*, function_name: str, key: str | None, output: Path, force: bool) -> None:
+    '''Capture output from one fully qualified HPI provider as JSONL.
+
+    Metadata is written to OUTPUT.meta.json.
+    This command and both file formats are experimental.
+    '''
+    from ._snapshot import snapshot_metadata_path, snapshot_provider, write_snapshot
+
+    snapshot = snapshot_provider(provider=function_name, key=key)
+    write_snapshot(snapshot=snapshot, path=output, overwrite=force)
+    click.echo(f'Wrote {len(snapshot.items)} items ({snapshot.error_count} errors) to {output}')
+    click.echo(f'Metadata: {snapshot_metadata_path(path=output)}')
+
+
+@dev_grp.command(name='diff', short_help='compare a snapshot with current provider output')
+@click.option('--key', default=None, type=str, help='Override the identity field stored in the snapshot.')
+@click.option('--details/--no-details', default=True, help='Include canonical unified diffs for changed items.')
+@click.option(
+    '--difftool',
+    default=None,
+    envvar='HPI_DIFFTOOL',
+    metavar='COMMAND',
+    help='Open temporary before.json and after.json files in the difftool.',
+)
+@click.argument('SNAPSHOT_FILE', type=click.Path(path_type=Path, exists=True, dir_okay=False))
+@click.argument('FUNCTION_NAME', required=False, type=str, shell_complete=_module_autocomplete)
+def dev_diff_cmd(
+    *,
+    snapshot_file: Path,
+    function_name: str | None,
+    key: str | None,
+    details: bool,
+    difftool: str | None,
+) -> None:
+    '''Compare saved JSONL with current provider output.
+
+    FUNCTION_NAME and --key default to values stored in the metadata sidecar.
+    FUNCTION_NAME is required for JSONL created by hpi query --stream.
+    --difftool receives temporary before.json and after.json paths.
+    The command exits with status 1 when the provider output has changed.
+    '''
+    from ._snapshot import (
+        compare_snapshots,
+        format_diff,
+        load_snapshot,
+        snapshot_metadata_path,
+        snapshot_provider,
+        write_diff_documents,
+    )
+
+    difftool_command: list[str] | None = None
+    if difftool is not None:
+        if not details:
+            raise click.UsageError('--difftool cannot be combined with --no-details.')
+        difftool_command = shlex.split(difftool)
+        if len(difftool_command) == 0:
+            raise click.BadParameter('must contain a command', param_hint='--difftool')
+
+    metadata_path = snapshot_metadata_path(path=snapshot_file)
+    if not metadata_path.exists() and function_name is None:
+        raise click.UsageError('FUNCTION_NAME is required when the JSONL file has no metadata sidecar.')
+
+    before = load_snapshot(path=snapshot_file, fallback_provider=function_name, fallback_key=key)
+    provider = before.provider if function_name is None else function_name
+    resolved_key = before.key if key is None else key
+    after = snapshot_provider(provider=provider, key=resolved_key)
+    diff = compare_snapshots(before=before, after=after, key=resolved_key)
+
+    click.echo(format_diff(diff=diff, details=details and difftool_command is None))
+
+    if difftool_command is not None and diff.has_changes:
+        with tempfile.TemporaryDirectory(prefix='hpi-diff-') as temp_dir:
+            before_path = Path(temp_dir) / 'before.json'
+            after_path = Path(temp_dir) / 'after.json'
+            has_item_changes = write_diff_documents(diff=diff, before_path=before_path, after_path=after_path)
+            if has_item_changes:
+                click.echo(f'Opening item details with {shlex.join(difftool_command)}', err=True)
+                run([*difftool_command, str(before_path), str(after_path)], check=False)
+            else:
+                click.echo('No item-level changes to open in the difftool.', err=True)
+
+    if diff.has_changes:
+        raise click.exceptions.Exit(1)
+
+
 @main.command(name='query', short_help='query the results of a HPI function')
 @click.option(
     '-o',

--- a/src/my/core/_snapshot.py
+++ b/src/my/core/_snapshot.py
@@ -1,0 +1,436 @@
+"""
+Experimental snapshots and diffs for HPI provider output.
+
+This module is a work in progress.
+Neither its Python API nor its JSONL and metadata file formats are stable.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from .query import locate_qualified_function
+from .serialize import dumps as hpi_dumps
+
+_FORMAT = 'hpi-provider-snapshot'
+_FORMAT_VERSION = 1
+_DATA_FORMAT = 'jsonl'
+_MISSING = object()
+
+
+@dataclass(frozen=True, kw_only=True)
+class Snapshot:
+    provider: str
+    key: str | None
+    created_at: datetime
+    items: tuple[Any, ...]
+    error_count: int
+
+
+@dataclass(frozen=True, kw_only=True)
+class SnapshotDiff:
+    """Semantic comparison of a baseline snapshot and newly collected provider output."""
+
+    before: Snapshot
+    """Baseline snapshot loaded from disk."""
+
+    after: Snapshot
+    """New snapshot collected from the provider."""
+
+    key: str | None
+    """Item field used as the key; author.id means the id field inside author, and None compares sequences directly."""
+
+    before_by_key: Mapping[str, tuple[Any, ...]]
+    """Baseline items grouped by key, empty when key is None."""
+
+    after_by_key: Mapping[str, tuple[Any, ...]]
+    """New items grouped by key, empty when key is None."""
+
+    unkeyed_before: tuple[Any, ...]
+    """Baseline items where key is missing, or every baseline item when key is None."""
+
+    unkeyed_after: tuple[Any, ...]
+    """New items where key is missing, or every new item when key is None."""
+
+    unchanged_keys: tuple[str, ...]
+    """Keys found in both snapshots whose items are identical."""
+
+    changed_keys: tuple[str, ...]
+    """Keys found in both snapshots whose items differ."""
+
+    added_keys: tuple[str, ...]
+    """Keys present only in the new snapshot."""
+
+    removed_keys: tuple[str, ...]
+    """Keys present only in the baseline snapshot."""
+
+    @property
+    def duplicate_before_keys(self) -> tuple[str, ...]:
+        return tuple(key for key, items in self.before_by_key.items() if len(items) > 1)
+
+    @property
+    def duplicate_after_keys(self) -> tuple[str, ...]:
+        return tuple(key for key, items in self.after_by_key.items() if len(items) > 1)
+
+    @property
+    def added_revision_count(self) -> int:
+        common_keys = self.before_by_key.keys() & self.after_by_key.keys()
+        return sum(max(len(self.after_by_key[key]) - len(self.before_by_key[key]), 0) for key in common_keys)
+
+    @property
+    def removed_revision_count(self) -> int:
+        common_keys = self.before_by_key.keys() & self.after_by_key.keys()
+        return sum(max(len(self.before_by_key[key]) - len(self.after_by_key[key]), 0) for key in common_keys)
+
+    @property
+    def has_changes(self) -> bool:
+        return (
+            len(self.changed_keys) > 0
+            or len(self.added_keys) > 0
+            or len(self.removed_keys) > 0
+            or self.unkeyed_before != self.unkeyed_after
+            or self.before.error_count != self.after.error_count
+        )
+
+
+def _to_json_value(value: Any) -> Any:
+    return json.loads(hpi_dumps(value))
+
+
+def _pretty_json(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True)
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(',', ':'))
+
+
+def _validate_key(*, key: str | None) -> None:
+    if key is None:
+        return
+    assert all(part != '' for part in key.split('.')), key
+
+
+def make_snapshot(
+    *,
+    provider: str,
+    items: Iterable[Any],
+    key: str | None = None,
+    created_at: datetime | None = None,
+) -> Snapshot:
+    assert provider != '', provider
+    _validate_key(key=key)
+
+    if created_at is None:
+        created_at = datetime.now(tz=UTC)
+    assert created_at.tzinfo is not None, created_at
+
+    json_items: list[Any] = []
+    error_count = 0
+    for item in items:
+        if isinstance(item, Exception):
+            error_count += 1
+        json_items.append(_to_json_value(item))
+
+    return Snapshot(
+        provider=provider,
+        key=key,
+        created_at=created_at,
+        items=tuple(json_items),
+        error_count=error_count,
+    )
+
+
+def snapshot_provider(*, provider: str, key: str | None = None) -> Snapshot:
+    function = locate_qualified_function(provider)
+    return make_snapshot(provider=provider, items=function(), key=key)
+
+
+def _snapshot_metadata_to_json(snapshot: Snapshot) -> dict[str, Any]:
+    return {
+        'format': _FORMAT,
+        'format_version': _FORMAT_VERSION,
+        'data_format': _DATA_FORMAT,
+        'provider': snapshot.provider,
+        'key': snapshot.key,
+        'created_at': snapshot.created_at.isoformat(),
+        'stats': {
+            'items': len(snapshot.items),
+            'errors': snapshot.error_count,
+        },
+    }
+
+
+def snapshot_metadata_path(*, path: Path) -> Path:
+    return path.with_name(f'{path.name}.meta.json')
+
+
+def write_snapshot(*, snapshot: Snapshot, path: Path, overwrite: bool = False) -> None:
+    metadata_path = snapshot_metadata_path(path=path)
+    if not overwrite:
+        for output_path in (path, metadata_path):
+            if output_path.exists():
+                raise FileExistsError(output_path)
+
+    mode = 'w' if overwrite else 'x'
+    with path.open(mode=mode) as fo:
+        for item in snapshot.items:
+            print(_canonical_json(item), file=fo)
+
+    with metadata_path.open(mode=mode) as fo:
+        print(_pretty_json(_snapshot_metadata_to_json(snapshot)), file=fo)
+
+
+def _load_jsonl(*, path: Path) -> tuple[Any, ...]:
+    items: list[Any] = []
+    with path.open() as fo:
+        for line_number, line in enumerate(fo, start=1):
+            assert line.strip() != '', (path, line_number)
+            items.append(json.loads(line))
+    return tuple(items)
+
+
+def _is_serialized_error(item: Any) -> bool:
+    return isinstance(item, dict) and set(item) == {'error'} and isinstance(item['error'], str)
+
+
+def load_snapshot(
+    *,
+    path: Path,
+    fallback_provider: str | None = None,
+    fallback_key: str | None = None,
+) -> Snapshot:
+    items = _load_jsonl(path=path)
+    metadata_path = snapshot_metadata_path(path=path)
+    if not metadata_path.exists():
+        assert fallback_provider is not None, path
+        assert fallback_provider != '', fallback_provider
+        _validate_key(key=fallback_key)
+        created_at = datetime.fromtimestamp(path.stat().st_mtime, tz=UTC)
+        error_count = sum(1 for item in items if _is_serialized_error(item))
+        return Snapshot(
+            provider=fallback_provider,
+            key=fallback_key,
+            created_at=created_at,
+            items=items,
+            error_count=error_count,
+        )
+
+    data = json.loads(metadata_path.read_text())
+    assert isinstance(data, dict), data
+    assert data['format'] == _FORMAT, data['format']
+    assert data['format_version'] == _FORMAT_VERSION, data['format_version']
+    assert data['data_format'] == _DATA_FORMAT, data['data_format']
+
+    provider = data['provider']
+    assert isinstance(provider, str), provider
+    assert provider != '', provider
+
+    key = data['key']
+    assert key is None or (isinstance(key, str) and key != ''), key
+    _validate_key(key=key)
+
+    created_at = datetime.fromisoformat(data['created_at'])
+    assert created_at.tzinfo is not None, created_at
+
+    stats = data['stats']
+    assert isinstance(stats, dict), stats
+    item_count = stats['items']
+    error_count = stats['errors']
+    assert type(item_count) is int, item_count
+    assert item_count >= 0, item_count
+    assert type(error_count) is int, error_count
+    assert error_count >= 0, error_count
+    assert item_count == len(items), (item_count, len(items))
+    assert error_count <= item_count, (error_count, item_count)
+
+    return Snapshot(
+        provider=provider,
+        key=key,
+        created_at=created_at,
+        items=items,
+        error_count=error_count,
+    )
+
+
+def _extract_key(*, item: Any, key: str) -> Any:
+    current = item
+    for part in key.split('.'):
+        if not isinstance(current, dict) or part not in current:
+            return _MISSING
+        current = current[part]
+    return current
+
+
+def _canonical_key(value: Any) -> str:
+    return _canonical_json(value)
+
+
+def _group_by_key(*, items: Iterable[Any], key: str | None) -> tuple[dict[str, tuple[Any, ...]], tuple[Any, ...]]:
+    if key is None:
+        return {}, tuple(items)
+
+    grouped: dict[str, list[Any]] = {}
+    unkeyed: list[Any] = []
+    for item in items:
+        value = _extract_key(item=item, key=key)
+        if value is _MISSING:
+            unkeyed.append(item)
+            continue
+        canonical_key = _canonical_key(value)
+        grouped.setdefault(canonical_key, []).append(item)
+
+    return {key: tuple(values) for key, values in grouped.items()}, tuple(unkeyed)
+
+
+def compare_snapshots(*, before: Snapshot, after: Snapshot, key: str | None = None) -> SnapshotDiff:
+    if key is None:
+        assert before.key == after.key, (before.key, after.key)
+        key = before.key
+    _validate_key(key=key)
+
+    before_by_key, unkeyed_before = _group_by_key(items=before.items, key=key)
+    after_by_key, unkeyed_after = _group_by_key(items=after.items, key=key)
+
+    before_keys = before_by_key.keys()
+    after_keys = after_by_key.keys()
+    common_keys = before_keys & after_keys
+
+    unchanged_keys = tuple(sorted(key for key in common_keys if before_by_key[key] == after_by_key[key]))
+    changed_keys = tuple(sorted(key for key in common_keys if before_by_key[key] != after_by_key[key]))
+    added_keys = tuple(sorted(after_keys - before_keys))
+    removed_keys = tuple(sorted(before_keys - after_keys))
+
+    return SnapshotDiff(
+        before=before,
+        after=after,
+        key=key,
+        before_by_key=before_by_key,
+        after_by_key=after_by_key,
+        unkeyed_before=unkeyed_before,
+        unkeyed_after=unkeyed_after,
+        unchanged_keys=unchanged_keys,
+        changed_keys=changed_keys,
+        added_keys=added_keys,
+        removed_keys=removed_keys,
+    )
+
+
+def _unified_diff(*, before: Any, after: Any, label: str) -> list[str]:
+    with tempfile.TemporaryDirectory(prefix='hpi-unified-diff-') as temp_dir:
+        before_path = Path(temp_dir) / 'before.json'
+        after_path = Path(temp_dir) / 'after.json'
+        before_path.write_text(f'{_pretty_json(before)}\n')
+        after_path.write_text(f'{_pretty_json(after)}\n')
+        result = subprocess.run(
+            [
+                'diff', '-u',
+                # replace temporary filename in the diff header with a stable before/after name.
+                '--label', f'before:{label}',
+                '--label', f'after:{label}',
+                str(before_path),
+                str(after_path),
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+        )  # fmt: skip
+    assert result.returncode in (0, 1), result
+    return result.stdout.splitlines()
+
+
+def _summary_rows(*, diff: SnapshotDiff) -> list[tuple[str, str]]:
+    provider = diff.before.provider
+    if diff.before.provider != diff.after.provider:
+        provider = f'{diff.before.provider} -> {diff.after.provider}'
+
+    rows = [
+        ('status', 'changed' if diff.has_changes else 'unchanged'),
+        ('provider', provider),
+        ('key', diff.key if diff.key is not None else '<sequence>'),
+        ('items', f'{len(diff.before.items)} -> {len(diff.after.items)}'),
+        ('errors', f'{diff.before.error_count} -> {diff.after.error_count}'),
+    ]
+    if diff.key is not None:
+        rows.extend(
+            [
+                ('unchanged keys', str(len(diff.unchanged_keys))),
+                ('changed keys', str(len(diff.changed_keys))),
+                ('added keys', str(len(diff.added_keys))),
+                ('removed keys', str(len(diff.removed_keys))),
+                ('new revisions of old keys', str(diff.added_revision_count)),
+                ('removed revisions of old keys', str(diff.removed_revision_count)),
+                ('duplicate keys before', str(len(diff.duplicate_before_keys))),
+                ('duplicate keys after', str(len(diff.duplicate_after_keys))),
+                ('unkeyed items', f'{len(diff.unkeyed_before)} -> {len(diff.unkeyed_after)}'),
+            ]
+        )
+    return rows
+
+
+def format_summary(*, diff: SnapshotDiff) -> str:
+    rows = _summary_rows(diff=diff)
+    width = max(len(label) for label, _value in rows)
+    lines = [f'{label + ":":<{width + 1}} {value}' for label, value in rows]
+    return '\n'.join(lines)
+
+
+def format_diff_details(*, diff: SnapshotDiff) -> str:
+    before, after = make_diff_documents(diff=diff)
+    label = diff.key if diff.key is not None else 'items'
+    detail_lines = _unified_diff(before=before, after=after, label=label)
+
+    if len(detail_lines) == 0:
+        return ''
+    return '\n'.join(('Details:', *detail_lines))
+
+
+def format_diff(*, diff: SnapshotDiff, details: bool = True) -> str:
+    summary = format_summary(diff=diff)
+    if not details or not diff.has_changes:
+        return summary
+
+    formatted_details = format_diff_details(diff=diff)
+    if formatted_details == '':
+        return summary
+    return f'{summary}\n\n{formatted_details}'
+
+
+def make_diff_documents(*, diff: SnapshotDiff) -> tuple[Any, Any]:
+    if diff.key is None:
+        return diff.unkeyed_before, diff.unkeyed_after
+
+    detail_keys = sorted(set(diff.changed_keys) | set(diff.added_keys) | set(diff.removed_keys))
+
+    def make_document(*, by_key: Mapping[str, tuple[Any, ...]], unkeyed: tuple[Any, ...]) -> dict[str, Any]:
+        groups = [
+            {
+                'key': json.loads(item_key),
+                'items': by_key.get(item_key, ()),
+            }
+            for item_key in detail_keys
+        ]
+        return {
+            'identity_key': diff.key,
+            'groups': groups,
+            'unkeyed_items': unkeyed if diff.unkeyed_before != diff.unkeyed_after else (),
+        }
+
+    before = make_document(by_key=diff.before_by_key, unkeyed=diff.unkeyed_before)
+    after = make_document(by_key=diff.after_by_key, unkeyed=diff.unkeyed_after)
+    return before, after
+
+
+def write_diff_documents(*, diff: SnapshotDiff, before_path: Path, after_path: Path) -> bool:
+    assert before_path != after_path, before_path
+    before, after = make_diff_documents(diff=diff)
+    before_path.write_text(f'{_pretty_json(before)}\n')
+    after_path.write_text(f'{_pretty_json(after)}\n')
+    return before != after

--- a/src/my/core/tests/test_snapshot.py
+++ b/src/my/core/tests/test_snapshot.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from my.core.__main__ import main
+from my.core._snapshot import (
+    compare_snapshots,
+    format_diff,
+    load_snapshot,
+    make_snapshot,
+    snapshot_metadata_path,
+    write_snapshot,
+)
+
+
+def snapshot_test_provider() -> list[dict[str, str]]:
+    return [
+        {'id': '1', 'value': 'current'},
+        {'id': '2', 'value': 'unchanged'},
+    ]
+
+
+def _decoded_keys(keys: tuple[str, ...]) -> tuple[object, ...]:
+    return tuple(json.loads(key) for key in keys)
+
+
+def test_snapshot_roundtrip(tmp_path: Path) -> None:
+    """Round-trip a snapshot and verify its JSONL, metadata, and overwrite behavior."""
+    created_at = datetime(2026, 8, 10, 12, 0, tzinfo=UTC)
+    snapshot = make_snapshot(
+        provider='my.example.items',
+        key='id',
+        created_at=created_at,
+        items=[
+            {'value': 'first', 'id': '1'},
+            RuntimeError('broken item'),
+        ],
+    )
+    path = tmp_path / 'snapshot.jsonl'
+    write_snapshot(snapshot=snapshot, path=path)
+
+    assert load_snapshot(path=path) == snapshot
+    assert path.read_text().splitlines()[0] == '{"id":"1","value":"first"}'
+
+    metadata_path = snapshot_metadata_path(path=path)
+    metadata = json.loads(metadata_path.read_text())
+    assert metadata['stats'] == {'errors': 1, 'items': 2}
+
+    with pytest.raises(FileExistsError):
+        write_snapshot(snapshot=snapshot, path=path)
+
+    write_snapshot(snapshot=snapshot, path=path, overwrite=True)
+    assert load_snapshot(path=path) == snapshot
+
+
+def test_malformed_key() -> None:
+    with pytest.raises(AssertionError):
+        make_snapshot(provider='my.example.items', key='author..id', items=[])
+
+
+def test_keyed_diff() -> None:
+    """Classify keyed changes and duplicate revisions, then render their details."""
+    created_at = datetime(2026, 8, 10, 12, 0, tzinfo=UTC)
+    before = make_snapshot(
+        provider='my.example.items',
+        key='id',
+        created_at=created_at,
+        items=[
+            {'id': 'question', 'text': 'Question only'},
+            {'id': 'same', 'text': 'Unchanged'},
+            {'id': 'removed', 'text': 'Removed'},
+        ],
+    )
+    after = make_snapshot(
+        provider='my.example.items',
+        key='id',
+        created_at=created_at,
+        items=[
+            {'id': 'question', 'text': 'Question\nMy answer\nTheir answer: '},
+            {'id': 'question', 'text': 'Question\nMy answer\nTheir answer: Answered'},
+            {'id': 'same', 'text': 'Unchanged'},
+            {'id': 'added', 'text': 'Added'},
+        ],
+    )
+
+    diff = compare_snapshots(before=before, after=after)
+    assert _decoded_keys(diff.unchanged_keys) == ('same',)
+    assert _decoded_keys(diff.changed_keys) == ('question',)
+    assert _decoded_keys(diff.added_keys) == ('added',)
+    assert _decoded_keys(diff.removed_keys) == ('removed',)
+    assert diff.added_revision_count == 1
+    assert _decoded_keys(diff.duplicate_before_keys) == ()
+    assert _decoded_keys(diff.duplicate_after_keys) == ('question',)
+    assert diff.has_changes
+
+    formatted = format_diff(diff=diff)
+    assert any(line.startswith('status:') and line.endswith('changed') for line in formatted.splitlines())
+    assert '--- before:id' in formatted
+    assert '+++ after:id' in formatted
+    assert 'Their answer: Answered' in formatted
+
+
+def test_dev_snapshot_cli_without_key(tmp_path: Path) -> None:
+    provider = 'my.core.tests.test_snapshot.snapshot_test_provider'
+    path = tmp_path / 'snapshot.jsonl'
+    runner = CliRunner()
+
+    captured = runner.invoke(main, ['dev', 'snapshot', '--output', str(path), provider])
+    assert captured.exit_code == 0, captured.output
+    assert 'Wrote 2 items (0 errors)' in captured.output
+    assert 'snapshot.jsonl.meta.json' in captured.output
+    assert snapshot_metadata_path(path=path).exists()
+
+    unchanged = runner.invoke(main, ['dev', 'diff', '--no-details', str(path)])
+    assert unchanged.exit_code == 0, unchanged.output
+    assert any(line.startswith('status:') and line.endswith('unchanged') for line in unchanged.output.splitlines())
+
+    before = make_snapshot(
+        provider=provider,
+        items=[
+            {'id': '1', 'value': 'before'},
+        ],
+    )
+    write_snapshot(snapshot=before, path=path, overwrite=True)
+
+    changed = runner.invoke(main, ['dev', 'diff', str(path)])
+    assert changed.exit_code == 1, changed.output
+    assert any(line.startswith('status:') and line.endswith('changed') for line in changed.output.splitlines())
+    assert any(line.startswith('items:') and line.endswith('1 -> 2') for line in changed.output.splitlines())
+
+
+def test_dev_diff_query_stream_jsonl(tmp_path: Path) -> None:
+    """Compare raw `hpi query --stream` JSONL without a snapshot metadata sidecar."""
+    provider = 'my.core.tests.test_snapshot.snapshot_test_provider'
+    path = tmp_path / 'query.jsonl'
+    runner = CliRunner()
+
+    query = runner.invoke(main, ['query', '--stream', provider])
+    assert query.exit_code == 0, query.output
+    path.write_text(query.output)
+    assert not snapshot_metadata_path(path=path).exists()
+
+    missing_provider = runner.invoke(main, ['dev', 'diff', '--no-details', str(path)])
+    assert missing_provider.exit_code == 2, missing_provider.output
+    assert 'FUNCTION_NAME is required' in missing_provider.output
+
+    unchanged = runner.invoke(main, ['dev', 'diff', '--no-details', '--key', 'id', str(path), provider])
+    assert unchanged.exit_code == 0, unchanged.output
+    assert any(line.startswith('status:') and line.endswith('unchanged') for line in unchanged.output.splitlines())


### PR DESCRIPTION
Capture provider output as JSONL and compare it with current results using optional identity keys, detailed diffs, and external difftools.

Basic usage:

    hpi dev snapshot --key id -o before.jsonl my.module.items
    hpi dev diff before.jsonl